### PR TITLE
Add <theoplayer-airplay-button>

### DIFF
--- a/examples/custom-ui.html
+++ b/examples/custom-ui.html
@@ -82,6 +82,7 @@
                 <span class="spacer"></span>
                 <theoplayer-language-menu-button menu="language-menu" mobile-only></theoplayer-language-menu-button>
                 <theoplayer-settings-menu-button menu="settings-menu" mobile-only></theoplayer-settings-menu-button>
+                <theoplayer-airplay-button mobile-only></theoplayer-airplay-button>
                 <theoplayer-chromecast-button mobile-only></theoplayer-chromecast-button>
             </theoplayer-control-bar>
             <theoplayer-loading-indicator slot="centered-loading" no-auto-hide></theoplayer-loading-indicator>
@@ -100,6 +101,7 @@
                     <span class="spacer"></span>
                     <theoplayer-language-menu-button menu="language-menu" mobile-hidden></theoplayer-language-menu-button>
                     <theoplayer-settings-menu-button menu="settings-menu" mobile-hidden></theoplayer-settings-menu-button>
+                    <theoplayer-airplay-button mobile-hidden></theoplayer-airplay-button>
                     <theoplayer-chromecast-button mobile-hidden></theoplayer-chromecast-button>
                     <theoplayer-fullscreen-button></theoplayer-fullscreen-button>
                 </theoplayer-control-bar>

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -6,6 +6,7 @@
         <span class="theoplayer-spacer"></span>
         <theoplayer-language-menu-button menu="language-menu" mobile-only ad-hidden></theoplayer-language-menu-button>
         <theoplayer-settings-menu-button menu="settings-menu" mobile-only ad-hidden></theoplayer-settings-menu-button>
+        <theoplayer-airplay-button mobile-only ad-hidden></theoplayer-airplay-button>
         <theoplayer-chromecast-button mobile-only ad-hidden></theoplayer-chromecast-button>
         <slot name="top-control-bar"></slot>
         <theoplayer-ad-clickthrough-button ad-only mobile-only></theoplayer-ad-clickthrough-button>
@@ -33,6 +34,7 @@
             <span class="theoplayer-spacer"></span>
             <theoplayer-language-menu-button menu="language-menu" mobile-hidden ad-hidden></theoplayer-language-menu-button>
             <theoplayer-settings-menu-button menu="settings-menu" mobile-hidden ad-hidden></theoplayer-settings-menu-button>
+            <theoplayer-airplay-button mobile-hidden ad-hidden></theoplayer-airplay-button>
             <theoplayer-chromecast-button mobile-hidden ad-hidden></theoplayer-chromecast-button>
             <slot name="bottom-control-bar"></slot>
             <theoplayer-fullscreen-button></theoplayer-fullscreen-button>

--- a/src/components/AirPlayButton.css
+++ b/src/components/AirPlayButton.css
@@ -1,0 +1,14 @@
+/* Unavailable: hide button */
+:host([cast-state='unavailable']) {
+    display: none !important;
+}
+
+/* Connected: fill screen */
+.theoplayer-airplay-inner {
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}
+
+:host([cast-state='connected']) .theoplayer-airplay-inner {
+    opacity: 1;
+}

--- a/src/components/AirPlayButton.html
+++ b/src/components/AirPlayButton.html
@@ -1,0 +1,6 @@
+<span part="icon">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" height="24" width="24">
+        <path class="theoplayer-airplay-inner" d="M5 7h14v8H5z" />
+        <path d="M6 22h12l-6-6zM21 3H3c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h4v-2H3V5h18v12h-4v2h4c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
+    </svg>
+</span>

--- a/src/components/AirPlayButton.ts
+++ b/src/components/AirPlayButton.ts
@@ -1,0 +1,38 @@
+import * as shadyCss from '@webcomponents/shadycss';
+import type { ChromelessPlayer } from 'theoplayer';
+import { StateReceiverMixin } from './StateReceiverMixin';
+import { CastButton } from './CastButton';
+import airPlayButtonHtml from './AirPlayButton.html';
+import airPlayButtonCss from './AirPlayButton.css';
+import { buttonTemplate } from './Button';
+
+const template = document.createElement('template');
+template.innerHTML = buttonTemplate(airPlayButtonHtml, airPlayButtonCss);
+shadyCss.prepareTemplate(template, 'theoplayer-airplay-button');
+
+/**
+ * A button to start and stop casting using AirPlay.
+ */
+export class AirPlayButton extends StateReceiverMixin(CastButton, ['player']) {
+    private _player: ChromelessPlayer | undefined;
+
+    constructor() {
+        super({ template });
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        this._upgradeProperty('player');
+    }
+
+    get player() {
+        return this._player;
+    }
+
+    set player(player: ChromelessPlayer | undefined) {
+        this._player = player;
+        this.castApi = player?.cast?.airplay;
+    }
+}
+
+customElements.define('theoplayer-airplay-button', AirPlayButton);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,6 +31,7 @@ export * from './VolumeRange';
 export * from './ErrorDisplay';
 export * from './CastButton';
 export * from './ChromecastButton';
+export * from './AirPlayButton';
 export * from './LoadingIndicator';
 export * from './GestureReceiver';
 export * from './PreviewTimeDisplay';


### PR DESCRIPTION
This adds a button to start and stop casting to an AirPlay device. It extends from the generic `CastButton`, so there's a lot of reuse with `ChromecastButton`.

Screenshots:
| Disconnected | Connected |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/649348/220321074-b4423396-944a-4f59-a5e2-99c70a7f901f.png) | ![image](https://user-images.githubusercontent.com/649348/220321344-13bdee9b-befa-4d5e-a7be-73d59a754eaf.png) |
