### PR TITLE
Upgrade properties inside constructor

### DIFF
--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -97,6 +97,22 @@ export class DefaultUI extends HTMLElement {
         this._titleSlot.addEventListener('slotchange', this._onTitleSlotChange);
 
         this._timeRange = shadowRoot.querySelector('theoplayer-time-range')!;
+
+        this._upgradeProperty('configuration');
+        this._upgradeProperty('source');
+        this._upgradeProperty('muted');
+        this._upgradeProperty('autoplay');
+        this._upgradeProperty('streamType');
+        this._upgradeProperty('userIdleTimeout');
+        this._upgradeProperty('dvrThreshold');
+    }
+
+    private _upgradeProperty(prop: keyof this) {
+        if (this.hasOwnProperty(prop)) {
+            let value = this[prop];
+            delete this[prop];
+            this[prop] = value;
+        }
     }
 
     /**
@@ -197,14 +213,6 @@ export class DefaultUI extends HTMLElement {
     connectedCallback(): void {
         shadyCss.styleElement(this);
 
-        this._upgradeProperty('configuration');
-        this._upgradeProperty('source');
-        this._upgradeProperty('muted');
-        this._upgradeProperty('autoplay');
-        this._upgradeProperty('streamType');
-        this._upgradeProperty('userIdleTimeout');
-        this._upgradeProperty('dvrThreshold');
-
         if (!this.hasAttribute(Attribute.MOBILE) && isMobile()) {
             this.setAttribute(Attribute.MOBILE, '');
         }
@@ -216,14 +224,6 @@ export class DefaultUI extends HTMLElement {
         }
 
         this._onTitleSlotChange();
-    }
-
-    private _upgradeProperty(prop: keyof this) {
-        if (this.hasOwnProperty(prop)) {
-            let value = this[prop];
-            delete this[prop];
-            this[prop] = value;
-        }
     }
 
     disconnectedCallback(): void {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -172,6 +172,21 @@ export class UIContainer extends HTMLElement {
         this._topChromeSlot.addEventListener('transitionend', this._onChromeSlotTransition);
         this._bottomChromeSlot.addEventListener('transitionstart', this._onChromeSlotTransition);
         this._bottomChromeSlot.addEventListener('transitionend', this._onChromeSlotTransition);
+
+        this._upgradeProperty('configuration');
+        this._upgradeProperty('source');
+        this._upgradeProperty('muted');
+        this._upgradeProperty('autoplay');
+        this._upgradeProperty('userIdleTimeout');
+        this._upgradeProperty('streamType');
+    }
+
+    private _upgradeProperty(prop: keyof this) {
+        if (this.hasOwnProperty(prop)) {
+            let value = this[prop];
+            delete this[prop];
+            this[prop] = value;
+        }
     }
 
     /**
@@ -330,13 +345,6 @@ export class UIContainer extends HTMLElement {
             this.setAttribute(Attribute.PAUSED, '');
         }
 
-        this._upgradeProperty('configuration');
-        this._upgradeProperty('source');
-        this._upgradeProperty('muted');
-        this._upgradeProperty('autoplay');
-        this._upgradeProperty('userIdleTimeout');
-        this._upgradeProperty('streamType');
-
         this.tryInitializePlayer_();
 
         for (const receiver of this._stateReceivers) {
@@ -363,14 +371,6 @@ export class UIContainer extends HTMLElement {
         this.addEventListener('pointerup', this._onPointerUp);
         this.addEventListener('pointermove', this._onPointerMove);
         this.addEventListener('mouseleave', this._onMouseLeave);
-    }
-
-    private _upgradeProperty(prop: keyof this) {
-        if (this.hasOwnProperty(prop)) {
-            let value = this[prop];
-            delete this[prop];
-            this[prop] = value;
-        }
     }
 
     private tryInitializePlayer_(): void {

--- a/src/components/AirPlayButton.ts
+++ b/src/components/AirPlayButton.ts
@@ -18,10 +18,6 @@ export class AirPlayButton extends StateReceiverMixin(CastButton, ['player']) {
 
     constructor() {
         super({ template });
-    }
-
-    connectedCallback() {
-        super.connectedCallback();
         this._upgradeProperty('player');
     }
 

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -41,6 +41,16 @@ export class Button extends HTMLElement {
         const template = options?.template ?? defaultTemplate;
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
+
+        this._upgradeProperty('disabled');
+    }
+
+    protected _upgradeProperty(prop: keyof this) {
+        if (this.hasOwnProperty(prop)) {
+            let value = this[prop];
+            delete this[prop];
+            this[prop] = value;
+        }
     }
 
     connectedCallback(): void {
@@ -53,8 +63,6 @@ export class Button extends HTMLElement {
             this.setAttribute('tabindex', '0');
         }
 
-        this._upgradeProperty('disabled');
-
         this.addEventListener('keydown', this._onKeyDown);
         this.addEventListener('click', this._onClick);
     }
@@ -62,14 +70,6 @@ export class Button extends HTMLElement {
     disconnectedCallback(): void {
         this.removeEventListener('keydown', this._onKeyDown);
         this.removeEventListener('click', this._onClick);
-    }
-
-    protected _upgradeProperty(prop: keyof this) {
-        if (this.hasOwnProperty(prop)) {
-            let value = this[prop];
-            delete this[prop];
-            this[prop] = value;
-        }
     }
 
     /**

--- a/src/components/CastButton.ts
+++ b/src/components/CastButton.ts
@@ -1,4 +1,4 @@
-import { Button } from './Button';
+import { Button, type ButtonOptions } from './Button';
 import { Attribute } from '../util/Attribute';
 import type { CastState, VendorCast } from 'theoplayer';
 import * as shadyCss from '@webcomponents/shadycss';
@@ -15,10 +15,14 @@ export class CastButton extends Button {
         return [...Button.observedAttributes, Attribute.CAST_STATE];
     }
 
-    override connectedCallback() {
-        super.connectedCallback();
+    constructor(options?: ButtonOptions) {
+        super(options);
         this._upgradeProperty('castState');
         this._upgradeProperty('castApi');
+    }
+
+    override connectedCallback() {
+        super.connectedCallback();
         if (!this.hasAttribute(Attribute.CAST_STATE)) {
             this.setAttribute(Attribute.CAST_STATE, 'unavailable');
         }

--- a/src/components/ChromecastButton.ts
+++ b/src/components/ChromecastButton.ts
@@ -29,10 +29,7 @@ export class ChromecastButton extends StateReceiverMixin(CastButton, ['player'])
         const uniqueMaskId = `${maskId}-${id}`;
         mask.setAttribute('id', uniqueMaskId);
         rings.setAttribute('clip-path', uniqueMaskId);
-    }
 
-    connectedCallback() {
-        super.connectedCallback();
         this._upgradeProperty('player');
     }
 

--- a/src/components/ChromecastDisplay.ts
+++ b/src/components/ChromecastDisplay.ts
@@ -30,16 +30,8 @@ export class ChromecastDisplay extends StateReceiverMixin(HTMLElement, ['player'
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
         this._receiverNameEl = shadowRoot.querySelector('[part="receiver"]')!;
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('player');
-
-        if (!this.hasAttribute(Attribute.HIDDEN)) {
-            this.setAttribute(Attribute.HIDDEN, '');
-        }
-        this._updateFromPlayer();
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -48,6 +40,14 @@ export class ChromecastDisplay extends StateReceiverMixin(HTMLElement, ['player'
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+        if (!this.hasAttribute(Attribute.HIDDEN)) {
+            this.setAttribute(Attribute.HIDDEN, '');
+        }
+        this._updateFromPlayer();
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/DurationDisplay.ts
+++ b/src/components/DurationDisplay.ts
@@ -23,12 +23,8 @@ export class DurationDisplay extends StateReceiverMixin(HTMLElement, ['player'])
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
         this._spanEl = shadowRoot.querySelector('span')!;
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('player');
-        this._updateFromPlayer();
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -37,6 +33,11 @@ export class DurationDisplay extends StateReceiverMixin(HTMLElement, ['player'])
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+        this._updateFromPlayer();
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/ErrorDisplay.ts
+++ b/src/components/ErrorDisplay.ts
@@ -37,10 +37,7 @@ export class ErrorDisplay extends StateReceiverMixin(HTMLElement, ['error', 'ful
         shadowRoot.appendChild(template.content.cloneNode(true));
 
         this._messageSlot = shadowRoot.querySelector('slot[name="message"]')!;
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('error');
     }
 
@@ -50,6 +47,10 @@ export class ErrorDisplay extends StateReceiverMixin(HTMLElement, ['error', 'ful
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
     }
 
     /**

--- a/src/components/FullscreenButton.ts
+++ b/src/components/FullscreenButton.ts
@@ -27,10 +27,6 @@ export class FullscreenButton extends StateReceiverMixin(Button, ['fullscreen'])
 
     constructor() {
         super({ template });
-    }
-
-    connectedCallback(): void {
-        super.connectedCallback();
         this._upgradeProperty('fullscreen');
     }
 

--- a/src/components/GestureReceiver.ts
+++ b/src/components/GestureReceiver.ts
@@ -21,15 +21,8 @@ export class GestureReceiver extends StateReceiverMixin(HTMLElement, ['player'])
         super();
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
-    }
-
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
 
         this._upgradeProperty('player');
-
-        this.setAttribute('tabindex', '-1');
-        this.setAttribute('aria-hidden', 'true');
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -38,6 +31,13 @@ export class GestureReceiver extends StateReceiverMixin(HTMLElement, ['player'])
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+
+        this.setAttribute('tabindex', '-1');
+        this.setAttribute('aria-hidden', 'true');
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/LanguageMenu.ts
+++ b/src/components/LanguageMenu.ts
@@ -26,10 +26,6 @@ export class LanguageMenu extends StateReceiverMixin(MenuGroup, ['player']) {
 
     constructor() {
         super({ template });
-    }
-
-    override connectedCallback(): void {
-        super.connectedCallback();
         this._upgradeProperty('player');
     }
 

--- a/src/components/LanguageMenuButton.ts
+++ b/src/components/LanguageMenuButton.ts
@@ -24,10 +24,6 @@ export class LanguageMenuButton extends StateReceiverMixin(MenuButton, ['player'
 
     constructor() {
         super({ template });
-    }
-
-    override connectedCallback() {
-        super.connectedCallback();
         this._upgradeProperty('player');
     }
 

--- a/src/components/LinkButton.ts
+++ b/src/components/LinkButton.ts
@@ -33,6 +33,16 @@ export class LinkButton extends HTMLElement {
         shadowRoot.appendChild(template.content.cloneNode(true));
 
         this._linkEl = shadowRoot.querySelector('a')!;
+
+        this._upgradeProperty('disabled');
+    }
+
+    protected _upgradeProperty(prop: keyof this) {
+        if (this.hasOwnProperty(prop)) {
+            let value = this[prop];
+            delete this[prop];
+            this[prop] = value;
+        }
     }
 
     connectedCallback(): void {
@@ -45,8 +55,6 @@ export class LinkButton extends HTMLElement {
             this.setAttribute('tabindex', '0');
         }
 
-        this._upgradeProperty('disabled');
-
         this._linkEl.addEventListener('keydown', this._onKeyDown);
         this._linkEl.addEventListener('click', this._onClick);
     }
@@ -54,14 +62,6 @@ export class LinkButton extends HTMLElement {
     disconnectedCallback(): void {
         this._linkEl.removeEventListener('keydown', this._onKeyDown);
         this._linkEl.removeEventListener('click', this._onClick);
-    }
-
-    protected _upgradeProperty(prop: keyof this) {
-        if (this.hasOwnProperty(prop)) {
-            let value = this[prop];
-            delete this[prop];
-            this[prop] = value;
-        }
     }
 
     /**

--- a/src/components/LiveButton.ts
+++ b/src/components/LiveButton.ts
@@ -37,10 +37,7 @@ export class LiveButton extends StateReceiverMixin(Button, ['player', 'streamTyp
 
     constructor() {
         super({ template });
-    }
 
-    override connectedCallback(): void {
-        super.connectedCallback();
         this._upgradeProperty('paused');
         this._upgradeProperty('streamType');
         this._upgradeProperty('liveThreshold');

--- a/src/components/LoadingIndicator.ts
+++ b/src/components/LoadingIndicator.ts
@@ -25,14 +25,11 @@ export class LoadingIndicator extends StateReceiverMixin(HTMLElement, ['player']
 
     constructor() {
         super();
+
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('player');
-        this._updateFromPlayer();
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -41,6 +38,11 @@ export class LoadingIndicator extends StateReceiverMixin(HTMLElement, ['player']
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+        this._updateFromPlayer();
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/MediaTrackRadioButton.ts
+++ b/src/components/MediaTrackRadioButton.ts
@@ -21,10 +21,7 @@ export class MediaTrackRadioButton extends RadioButton {
     constructor() {
         super({ template });
         this._slotEl = this.shadowRoot!.querySelector('slot')!;
-    }
 
-    override connectedCallback(): void {
-        super.connectedCallback();
         this._upgradeProperty('track');
     }
 

--- a/src/components/Menu.ts
+++ b/src/components/Menu.ts
@@ -55,6 +55,14 @@ export class Menu extends HTMLElement {
         this._contentEl = shadowRoot.querySelector('[part="content"]')!;
     }
 
+    protected _upgradeProperty(prop: keyof this) {
+        if (this.hasOwnProperty(prop)) {
+            let value = this[prop];
+            delete this[prop];
+            this[prop] = value;
+        }
+    }
+
     connectedCallback(): void {
         shadyCss.styleElement(this);
 
@@ -67,14 +75,6 @@ export class Menu extends HTMLElement {
 
     disconnectedCallback(): void {
         this._contentEl.removeEventListener('input', this._onContentInput);
-    }
-
-    protected _upgradeProperty(prop: keyof this) {
-        if (this.hasOwnProperty(prop)) {
-            let value = this[prop];
-            delete this[prop];
-            this[prop] = value;
-        }
     }
 
     /**

--- a/src/components/MenuButton.ts
+++ b/src/components/MenuButton.ts
@@ -20,12 +20,12 @@ export class MenuButton extends Button {
 
     constructor(options?: Partial<ButtonOptions>) {
         super({ template, ...options });
+
+        this._upgradeProperty('menu');
     }
 
     override connectedCallback() {
         super.connectedCallback();
-
-        this._upgradeProperty('menu');
 
         if (!this.hasAttribute('aria-haspopup')) {
             this.setAttribute('aria-haspopup', 'true');

--- a/src/components/MenuGroup.ts
+++ b/src/components/MenuGroup.ts
@@ -56,6 +56,14 @@ export class MenuGroup extends HTMLElement {
         this._menuSlot = shadowRoot.querySelector('slot');
     }
 
+    protected _upgradeProperty(prop: keyof this) {
+        if (this.hasOwnProperty(prop)) {
+            let value = this[prop];
+            delete this[prop];
+            this[prop] = value;
+        }
+    }
+
     connectedCallback(): void {
         shadyCss.styleElement(this);
 
@@ -76,14 +84,6 @@ export class MenuGroup extends HTMLElement {
         this.shadowRoot!.removeEventListener(CLOSE_MENU_EVENT, this._onCloseMenu);
         this.shadowRoot!.removeEventListener(MENU_CHANGE_EVENT, this._onMenuChange);
         this._menuSlot?.removeEventListener('slotchange', this._onMenuListChange);
-    }
-
-    protected _upgradeProperty(prop: keyof this) {
-        if (this.hasOwnProperty(prop)) {
-            let value = this[prop];
-            delete this[prop];
-            this[prop] = value;
-        }
     }
 
     attributeChangedCallback(attrName: string, oldValue: any, newValue: any) {

--- a/src/components/MuteButton.ts
+++ b/src/components/MuteButton.ts
@@ -36,11 +36,11 @@ export class MuteButton extends StateReceiverMixin(Button, ['player']) {
 
     constructor() {
         super({ template });
+        this._upgradeProperty('player');
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
-        this._upgradeProperty('player');
         this._updateFromPlayer();
     }
 

--- a/src/components/PlayButton.ts
+++ b/src/components/PlayButton.ts
@@ -32,13 +32,13 @@ export class PlayButton extends StateReceiverMixin(Button, ['player']) {
 
     constructor() {
         super({ template });
+        this._upgradeProperty('paused');
+        this._upgradeProperty('ended');
+        this._upgradeProperty('player');
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
-        this._upgradeProperty('paused');
-        this._upgradeProperty('ended');
-        this._upgradeProperty('player');
         this._updateFromPlayer();
     }
 

--- a/src/components/PlaybackRateRadioGroup.ts
+++ b/src/components/PlaybackRateRadioGroup.ts
@@ -36,21 +36,10 @@ export class PlaybackRateRadioGroup extends StateReceiverMixin(HTMLElement, ['pl
         shadowRoot.appendChild(template.content.cloneNode(true));
 
         this._radioGroup = shadowRoot.querySelector('theoplayer-radio-group')!;
-    }
-
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
 
         this._upgradeProperty('value');
         this._upgradeProperty('values');
         this._upgradeProperty('player');
-
-        this._updateValues();
-        this.shadowRoot!.addEventListener('change', this._onChange);
-    }
-
-    disconnectedCallback(): void {
-        this.shadowRoot!.removeEventListener('change', this._onChange);
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -59,6 +48,17 @@ export class PlaybackRateRadioGroup extends StateReceiverMixin(HTMLElement, ['pl
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+
+        this._updateValues();
+        this.shadowRoot!.addEventListener('change', this._onChange);
+    }
+
+    disconnectedCallback(): void {
+        this.shadowRoot!.removeEventListener('change', this._onChange);
     }
 
     /**

--- a/src/components/PreviewThumbnail.ts
+++ b/src/components/PreviewThumbnail.ts
@@ -40,10 +40,7 @@ export class PreviewThumbnail extends StateReceiverMixin(HTMLElement, ['player',
 
         this._thumbnailImageSource = document.createElement('img');
         this._thumbnailImageSource.decoding = 'async';
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('previewTime');
         this._upgradeProperty('player');
     }
@@ -54,6 +51,10 @@ export class PreviewThumbnail extends StateReceiverMixin(HTMLElement, ['player',
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/PreviewTimeDisplay.ts
+++ b/src/components/PreviewTimeDisplay.ts
@@ -34,13 +34,9 @@ export class PreviewTimeDisplay extends StateReceiverMixin(HTMLElement, ['player
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
         this._spanEl = shadowRoot.querySelector('span')!;
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('previewTime');
         this._upgradeProperty('player');
-        this._update();
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -49,6 +45,11 @@ export class PreviewTimeDisplay extends StateReceiverMixin(HTMLElement, ['player
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+        this._update();
     }
 
     get previewTime(): number {

--- a/src/components/QualityRadioButton.ts
+++ b/src/components/QualityRadioButton.ts
@@ -25,10 +25,6 @@ export class QualityRadioButton extends RadioButton {
     constructor() {
         super({ template });
         this._slotEl = this.shadowRoot!.querySelector('slot')!;
-    }
-
-    override connectedCallback(): void {
-        super.connectedCallback();
 
         this._upgradeProperty('track');
         this._upgradeProperty('quality');

--- a/src/components/QualityRadioGroup.ts
+++ b/src/components/QualityRadioGroup.ts
@@ -28,19 +28,8 @@ export class QualityRadioGroup extends StateReceiverMixin(HTMLElement, ['player'
         shadowRoot.appendChild(template.content.cloneNode(true));
 
         this._radioGroup = shadowRoot.querySelector('theoplayer-radio-group')!;
-    }
-
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
 
         this._upgradeProperty('player');
-        this._updateTrack();
-
-        this.shadowRoot!.addEventListener('change', this._onChange);
-    }
-
-    disconnectedCallback(): void {
-        this.shadowRoot!.removeEventListener('change', this._onChange);
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -49,6 +38,16 @@ export class QualityRadioGroup extends StateReceiverMixin(HTMLElement, ['player'
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+        this._updateTrack();
+        this.shadowRoot!.addEventListener('change', this._onChange);
+    }
+
+    disconnectedCallback(): void {
+        this.shadowRoot!.removeEventListener('change', this._onChange);
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/RadioButton.ts
+++ b/src/components/RadioButton.ts
@@ -22,11 +22,10 @@ export class RadioButton extends Button {
 
     constructor(options?: ButtonOptions) {
         super({ template: defaultTemplate, ...options });
+        this._upgradeProperty('checked');
     }
 
     override connectedCallback() {
-        this._upgradeProperty('checked');
-
         if (!this.hasAttribute('role')) {
             this.setAttribute('role', 'radio');
         }

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -36,16 +36,24 @@ export abstract class Range extends HTMLElement {
         this._rangeEl.addEventListener('change', this._onInput);
 
         this._pointerEl = shadowRoot.querySelector('[part="pointer"]')!;
-    }
-
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
 
         this._upgradeProperty('disabled');
         this._upgradeProperty('value');
         this._upgradeProperty('min');
         this._upgradeProperty('max');
         this._upgradeProperty('step');
+    }
+
+    protected _upgradeProperty(prop: keyof this) {
+        if (this.hasOwnProperty(prop)) {
+            let value = this[prop];
+            delete this[prop];
+            this[prop] = value;
+        }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
 
         this._rangeEl.setAttribute('aria-label', this.getAriaLabel());
         this.update();
@@ -55,14 +63,6 @@ export abstract class Range extends HTMLElement {
 
     disconnectedCallback(): void {
         this.removeEventListener('pointermove', this._updatePointerBar);
-    }
-
-    protected _upgradeProperty(prop: keyof this) {
-        if (this.hasOwnProperty(prop)) {
-            let value = this[prop];
-            delete this[prop];
-            this[prop] = value;
-        }
     }
 
     /**

--- a/src/components/TextTrackOffRadioButton.ts
+++ b/src/components/TextTrackOffRadioButton.ts
@@ -19,10 +19,6 @@ export class TextTrackOffRadioButton extends RadioButton {
 
     constructor() {
         super({ template });
-    }
-
-    override connectedCallback() {
-        super.connectedCallback();
         this._upgradeProperty('trackList');
     }
 

--- a/src/components/TextTrackRadioButton.ts
+++ b/src/components/TextTrackRadioButton.ts
@@ -21,10 +21,6 @@ export class TextTrackRadioButton extends RadioButton {
     constructor() {
         super({ template });
         this._slotEl = this.shadowRoot!.querySelector('slot')!;
-    }
-
-    override connectedCallback(): void {
-        super.connectedCallback();
         this._upgradeProperty('track');
     }
 

--- a/src/components/TimeDisplay.ts
+++ b/src/components/TimeDisplay.ts
@@ -33,15 +33,12 @@ export class TimeDisplay extends StateReceiverMixin(HTMLElement, ['player', 'str
 
     constructor() {
         super();
+
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
         this._spanEl = shadowRoot.querySelector('span')!;
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('player');
-        this._updateFromPlayer();
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -50,6 +47,11 @@ export class TimeDisplay extends StateReceiverMixin(HTMLElement, ['player', 'str
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+        this._updateFromPlayer();
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -52,11 +52,12 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
 
         this._rangeEl.addEventListener('mousedown', this._pauseOnScrubStart);
         this._rangeEl.addEventListener('touchstart', this._pauseOnScrubStart);
+
+        this._upgradeProperty('player');
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
-        this._upgradeProperty('player');
         this._toggleAutoAdvance();
     }
 

--- a/src/components/TrackRadioGroup.ts
+++ b/src/components/TrackRadioGroup.ts
@@ -43,14 +43,22 @@ export class TrackRadioGroup extends StateReceiverMixin(HTMLElement, ['player'])
         shadowRoot.appendChild(template.content.cloneNode(true));
 
         this._radioGroup = shadowRoot.querySelector('theoplayer-radio-group')!;
-    }
-
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
 
         this._upgradeProperty('trackType');
         this._upgradeProperty('showOffButton');
         this._upgradeProperty('player');
+    }
+
+    protected _upgradeProperty(prop: keyof this) {
+        if (this.hasOwnProperty(prop)) {
+            let value = this[prop];
+            delete this[prop];
+            this[prop] = value;
+        }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
 
         this._updateOffButton();
         this._updateTracks();
@@ -60,14 +68,6 @@ export class TrackRadioGroup extends StateReceiverMixin(HTMLElement, ['player'])
 
     disconnectedCallback(): void {
         this.shadowRoot!.removeEventListener('change', this._onChange);
-    }
-
-    protected _upgradeProperty(prop: keyof this) {
-        if (this.hasOwnProperty(prop)) {
-            let value = this[prop];
-            delete this[prop];
-            this[prop] = value;
-        }
     }
 
     /**

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -19,10 +19,6 @@ export class VolumeRange extends StateReceiverMixin(Range, ['player']) {
 
     constructor() {
         super({ template });
-    }
-
-    override connectedCallback() {
-        super.connectedCallback();
         this._upgradeProperty('player');
     }
 

--- a/src/components/ads/AdClickThroughButton.ts
+++ b/src/components/ads/AdClickThroughButton.ts
@@ -21,12 +21,12 @@ export class AdClickThroughButton extends StateReceiverMixin(LinkButton, ['playe
 
     constructor() {
         super({ template });
+        this._upgradeProperty('clickThrough');
+        this._upgradeProperty('player');
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
-        this._upgradeProperty('clickThrough');
-        this._upgradeProperty('player');
         this._updateFromPlayer();
     }
 

--- a/src/components/ads/AdCountdown.ts
+++ b/src/components/ads/AdCountdown.ts
@@ -20,12 +20,8 @@ export class AdCountdown extends StateReceiverMixin(HTMLElement, ['player']) {
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
         this._spanEl = shadowRoot.querySelector('span')!;
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('player');
-        this._update();
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -34,6 +30,11 @@ export class AdCountdown extends StateReceiverMixin(HTMLElement, ['player']) {
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+        this._update();
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/ads/AdDisplay.ts
+++ b/src/components/ads/AdDisplay.ts
@@ -21,12 +21,8 @@ export class AdDisplay extends StateReceiverMixin(HTMLElement, ['player']) {
         const shadowRoot = this.attachShadow({ mode: 'open' });
         shadowRoot.appendChild(template.content.cloneNode(true));
         this._spanEl = shadowRoot.querySelector('span')!;
-    }
 
-    connectedCallback(): void {
-        shadyCss.styleElement(this);
         this._upgradeProperty('player');
-        this._updateFromPlayer();
     }
 
     protected _upgradeProperty(prop: keyof this) {
@@ -35,6 +31,11 @@ export class AdDisplay extends StateReceiverMixin(HTMLElement, ['player']) {
             delete this[prop];
             this[prop] = value;
         }
+    }
+
+    connectedCallback(): void {
+        shadyCss.styleElement(this);
+        this._updateFromPlayer();
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/ads/AdSkipButton.ts
+++ b/src/components/ads/AdSkipButton.ts
@@ -34,11 +34,12 @@ export class AdSkipButton extends StateReceiverMixin(Button, ['player']) {
         super({ template });
         this._countdownEl = this.shadowRoot!.querySelector('[part="countdown"]')!;
         this._skipEl = this.shadowRoot!.querySelector('[part="skip"]')!;
+
+        this._upgradeProperty('player');
     }
 
     override connectedCallback(): void {
         super.connectedCallback();
-        this._upgradeProperty('player');
         this._update();
     }
 


### PR DESCRIPTION
When a property is set on a custom element before its definition is loaded, that property won't yet trigger any custom logic from the (future) setter. The [Custom Elements Best Practices article on web.dev](https://web.dev/custom-elements-best-practices/#make-properties-lazy) recommends handling this by "upgrading" these properties inside the `connectedCallback`.

However, when there's also an attribute that sets this same property, the property upgrade may happen *after* `attributeChangedCallback` fires. This can subtly break some of the assumptions in our code.

To avoid this, we now upgrade properties *immediately* as part of the custom element's constructor. This should make the behavior more predictable.