### PR TITLE
Improved advertisement support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ## Unreleased
 
+-   🚀 Improved support for advertisements ([#28](https://github.com/THEOplayer/web-ui/pull/28))
+    -   Reworked the ad control bar in `<theoplayer-default-ui>`.
+    -   Added a `show-ad-markers` attribute to `<theoplayer-time-range>`, to show markers on the progress bar indicating when the content will be interrupted by an advertisement.
+    -   `<theoplayer-ad-skip-button>` and `<theoplayer-ad-clickthrough-button>` are automatically hidden while playing a Google IMA ad. (This is unfortunately necessary, because Google IMA doesn't provide a way to modify or replace its own buttons.)
 -   🐛 When the player changes sources, any open menu is now automatically closed
 
 ## v1.1.0 (2023-04-12)

--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -2,6 +2,16 @@
 layout: page
 ---
 
+<style>
+    theoplayer-ui:not(:defined),
+    theoplayer-default-ui:not(:defined) {
+        display: inline-block;
+        box-sizing: border-box;
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        background: #000;
+    }
+</style>
 <script nomodule src="https://polyfill.io/v3/polyfill.min.js?features=es2015"></script>
 <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/custom-elements-es5-adapter.js"></script>
 <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/webcomponents-bundle.js"></script>

--- a/docs/examples/ads.html
+++ b/docs/examples/ads.html
@@ -14,9 +14,9 @@ permalink: /examples/ads
 <theoplayer-default-ui configuration='{"libraryLocation":"https://unpkg.com/theoplayer@5/","license":"{{ site.theoplayer_license }}"}' fluid>
     <span slot="title">Elephant's Dream</span>
 </theoplayer-default-ui>
-<div>
+<p>
     <label style="user-select: none"><input type="checkbox" id="mobile-toggle" /> Mobile</label>
-</div>
+</p>
 
 <p>The default UI has full support for advertisements.</p>
 

--- a/docs/examples/ads.html
+++ b/docs/examples/ads.html
@@ -1,0 +1,51 @@
+---
+layout: example
+title: Advertisements
+permalink: /examples/ads
+---
+
+<style>
+    theoplayer-default-ui {
+        font-family: 'Noto Sans', sans-serif;
+        width: 100%;
+    }
+</style>
+
+<theoplayer-default-ui configuration='{"libraryLocation":"https://unpkg.com/theoplayer@5/","license":"{{ site.theoplayer_license }}"}' fluid>
+    <span slot="title">Elephant's Dream</span>
+</theoplayer-default-ui>
+<div>
+    <label style="user-select: none"><input type="checkbox" id="mobile-toggle" /> Mobile</label>
+</div>
+
+<p>The default UI has full support for advertisements.</p>
+
+<p>During playback, it shows yellow ad markers on the seek bar to indicate the times when the content will be interrupted by an ad.</p>
+
+<p>
+    While playing an ad, the UI shows ad-specific controls such as a skip button and a countdown. These controls are also mobile-aware, for example a
+    dedicated clickthrough button replaces the regular clickthrough behavior on desktop.
+</p>
+
+<script>
+    var ui = document.querySelector('theoplayer-default-ui');
+    ui.source = {
+        sources:
+            'https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)',
+        ads: [
+            {
+                sources: {
+                    src: 'https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/vmap_ad_samples&sz=640x480&cust_params=sample_ar%3Dpremidpostpod&ciu_szs=300x250&gdfp_req=1&ad_rule=1&output=vmap&unviewed_position_start=1&env=vp&impl=s&cmsid=496&vid=short_onecue&correlator=',
+                    type: 'vmap'
+                }
+            }
+        ]
+    };
+    document.querySelector('#mobile-toggle').addEventListener('change', function (ev) {
+        if (ev.target.checked) {
+            ui.setAttribute('mobile', '');
+        } else {
+            ui.removeAttribute('mobile');
+        }
+    });
+</script>

--- a/docs/examples/custom-ui.html
+++ b/docs/examples/custom-ui.html
@@ -100,9 +100,9 @@ permalink: /examples/custom-ui
     <theoplayer-settings-menu id="settings-menu" slot="menu" hidden></theoplayer-settings-menu>
     <theoplayer-error-display slot="error"></theoplayer-error-display>
 </theoplayer-ui>
-<div>
+<p>
     <label style="user-select: none"><input type="checkbox" id="mobile-toggle" /> Mobile</label>
-</div>
+</p>
 <script>
     var ui = document.querySelector('theoplayer-ui');
     document.querySelector('#mobile-toggle').addEventListener('change', function (ev) {

--- a/docs/examples/default-ui.html
+++ b/docs/examples/default-ui.html
@@ -18,9 +18,9 @@ permalink: /examples/default-ui
 >
     <span slot="title">Elephant's Dream</span>
 </theoplayer-default-ui>
-<div>
+<p>
     <label style="user-select: none"><input type="checkbox" id="mobile-toggle" /> Mobile</label>
-</div>
+</p>
 <script>
     var ui = document.querySelector('theoplayer-default-ui');
     document.querySelector('#mobile-toggle').addEventListener('change', function (ev) {

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -6,5 +6,6 @@ show_in_nav: true
 ---
 
 -   [Default UI](./default-ui.html)
+    -   [Advertisements](./ads.html)
 -   [Custom UI](./custom-ui.html)
 -   [Nitflex theme](./nitflex.html)

--- a/src/DefaultUI.css
+++ b/src/DefaultUI.css
@@ -232,3 +232,8 @@ theoplayer-live-button + theoplayer-time-display:not([stream-type='vod']) {
 theoplayer-live-button[live] + theoplayer-time-display {
     display: none !important;
 }
+
+/* Use smaller playback controls while playing an ad */
+theoplayer-ui[playing-ad] .theoplayer-ad-control {
+    --theoplayer-control-height: 16px;
+}

--- a/src/DefaultUI.css
+++ b/src/DefaultUI.css
@@ -52,6 +52,7 @@ theoplayer-ui {
     display: flex;
     flex-flow: column nowrap;
     align-items: stretch;
+    pointer-events: none;
 }
 
 /*

--- a/src/DefaultUI.css
+++ b/src/DefaultUI.css
@@ -133,7 +133,6 @@ theoplayer-ad-skip-button[disabled] {
 }
 
 theoplayer-ad-countdown {
-    justify-content: flex-start;
     min-width: 0;
 }
 

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -37,7 +37,7 @@
             <theoplayer-volume-range mobile-hidden></theoplayer-volume-range>
             <theoplayer-live-button live-only ad-hidden></theoplayer-live-button>
             <theoplayer-time-display show-duration remaining-when-live></theoplayer-time-display>
-            <span class="theoplayer-spacer"></span>
+            <span class="theoplayer-spacer" style="pointer-events: auto"></span>
             <theoplayer-language-menu-button menu="language-menu" mobile-hidden ad-hidden></theoplayer-language-menu-button>
             <theoplayer-airplay-button mobile-hidden ad-hidden></theoplayer-airplay-button>
             <theoplayer-chromecast-button mobile-hidden ad-hidden></theoplayer-chromecast-button>

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -19,13 +19,13 @@
     <div slot="middle-chrome" part="middle-chrome">
         <theoplayer-chromecast-display></theoplayer-chromecast-display>
     </div>
-    <theoplayer-control-bar part="ad-chrome" ad-only>
-        <theoplayer-ad-display></theoplayer-ad-display>
-        <theoplayer-ad-countdown></theoplayer-ad-countdown>
-        <span class="theoplayer-spacer"></span>
-        <theoplayer-ad-skip-button></theoplayer-ad-skip-button>
-    </theoplayer-control-bar>
     <div part="bottom-chrome">
+        <theoplayer-control-bar part="ad-chrome" ad-only>
+            <theoplayer-ad-display></theoplayer-ad-display>
+            <theoplayer-ad-countdown></theoplayer-ad-countdown>
+            <span class="theoplayer-spacer"></span>
+            <theoplayer-ad-skip-button></theoplayer-ad-skip-button>
+        </theoplayer-control-bar>
         <theoplayer-control-bar>
             <theoplayer-time-range show-ad-markers></theoplayer-time-range>
         </theoplayer-control-bar>

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -27,7 +27,7 @@
     </theoplayer-control-bar>
     <div part="bottom-chrome">
         <theoplayer-control-bar>
-            <theoplayer-time-range></theoplayer-time-range>
+            <theoplayer-time-range show-ad-markers></theoplayer-time-range>
         </theoplayer-control-bar>
         <theoplayer-control-bar>
             <theoplayer-play-button mobile-hidden></theoplayer-play-button>

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -12,9 +12,9 @@
     </theoplayer-control-bar>
     <theoplayer-loading-indicator slot="centered-loading" no-auto-hide></theoplayer-loading-indicator>
     <div slot="centered-chrome" part="centered-chrome">
-        <theoplayer-seek-button seek-offset="-10" mobile-only></theoplayer-seek-button>
+        <theoplayer-seek-button seek-offset="-10" mobile-only ad-hidden></theoplayer-seek-button>
         <theoplayer-play-button></theoplayer-play-button>
-        <theoplayer-seek-button seek-offset="10" mobile-only></theoplayer-seek-button>
+        <theoplayer-seek-button seek-offset="10" mobile-only ad-hidden></theoplayer-seek-button>
     </div>
     <div slot="middle-chrome" part="middle-chrome">
         <theoplayer-chromecast-display></theoplayer-chromecast-display>

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -27,9 +27,11 @@
             <theoplayer-ad-skip-button></theoplayer-ad-skip-button>
         </theoplayer-control-bar>
         <theoplayer-control-bar>
-            <theoplayer-time-range show-ad-markers></theoplayer-time-range>
+            <theoplayer-play-button mobile-hidden ad-only class="theoplayer-ad-control"></theoplayer-play-button>
+            <theoplayer-mute-button ad-only class="theoplayer-ad-control"></theoplayer-mute-button>
+            <theoplayer-time-range show-ad-markers class="theoplayer-ad-control"></theoplayer-time-range>
         </theoplayer-control-bar>
-        <theoplayer-control-bar>
+        <theoplayer-control-bar ad-hidden>
             <theoplayer-play-button mobile-hidden></theoplayer-play-button>
             <theoplayer-mute-button></theoplayer-mute-button>
             <theoplayer-volume-range mobile-hidden></theoplayer-volume-range>

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -92,8 +92,8 @@ export class DefaultUI extends HTMLElement {
         shadowRoot.appendChild(template.content.cloneNode(true));
 
         this._ui = shadowRoot.querySelector('theoplayer-ui')!;
-        this._ui.configuration = configuration;
         this._ui.addEventListener(STREAM_TYPE_CHANGE_EVENT, this._updateStreamType);
+        this.setConfiguration_(configuration);
 
         this._titleSlot = shadowRoot.querySelector('slot[name="title"]')!;
         this._titleSlot.addEventListener('slotchange', this._onTitleSlotChange);
@@ -137,7 +137,19 @@ export class DefaultUI extends HTMLElement {
 
     set configuration(configuration: PlayerConfiguration) {
         this.removeAttribute(Attribute.CONFIGURATION);
-        this._ui.configuration = configuration;
+        this.setConfiguration_(configuration);
+    }
+
+    private setConfiguration_(configuration: PlayerConfiguration) {
+        this._ui.configuration = {
+            ...configuration,
+            ads: {
+                ...(configuration.ads ?? {}),
+                // Always disable Google IMA's own ad countdown,
+                // since we show our own countdown in the default UI.
+                showCountdown: false
+            }
+        };
     }
 
     /**
@@ -240,7 +252,7 @@ export class DefaultUI extends HTMLElement {
         if (attrName === Attribute.SOURCE) {
             this._ui.source = newValue ? (JSON.parse(newValue) as SourceDescription) : undefined;
         } else if (attrName === Attribute.CONFIGURATION) {
-            this._ui.configuration = newValue ? (JSON.parse(newValue) as PlayerConfiguration) : {};
+            this.setConfiguration_(newValue ? (JSON.parse(newValue) as PlayerConfiguration) : {});
         } else if (attrName === Attribute.MUTED) {
             this.muted = hasValue;
         } else if (attrName === Attribute.AUTOPLAY) {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -414,7 +414,8 @@ export class UIContainer extends HTMLElement {
         this._player.addEventListener('sourcechange', this._onSourceChange);
         this._player.videoTracks.addEventListener(['addtrack', 'removetrack', 'change'], this._updateActiveVideoTrack);
         this._player.cast?.addEventListener('castingchange', this._updateCasting);
-        this._player.ads?.addEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend'], this._updatePlayingAd);
+        this._player.addEventListener(['durationchange', 'sourcechange', 'emptied'], this._updatePlayingAd);
+        this._player.ads?.addEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend', 'adskip'], this._updatePlayingAd);
     }
 
     disconnectedCallback(): void {

--- a/src/components/GestureReceiver.ts
+++ b/src/components/GestureReceiver.ts
@@ -83,6 +83,10 @@ export class GestureReceiver extends StateReceiverMixin(HTMLElement, ['player'])
     handleMouseClick(_event: MouseEvent): void {
         // Toggle play/pause.
         if (this._player !== undefined) {
+            if (this._player?.ads?.playing) {
+                // Clicking during a linear ad should open the ad's clickthrough URL instead.
+                return;
+            }
             if (this._player.paused) {
                 this._player.play();
             } else {

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -1,6 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import rangeCss from './Range.css';
 import { Attribute } from '../util/Attribute';
+import { ColorStops } from '../util/ColorStops';
 
 export interface RangeOptions {
     template: HTMLTemplateElement;
@@ -189,19 +190,9 @@ export abstract class Range extends HTMLElement {
      * by using a background gradient that moves with the range value.
      */
     private updateBar_() {
-        const colorArray = this.getBarColors();
-
-        const gradientStops: string[] = [];
-        let prevPercent = 0;
-        for (const [color, percent] of colorArray) {
-            if (percent < prevPercent) continue;
-            gradientStops.push(`${color} ${prevPercent}%`);
-            gradientStops.push(`${color} ${percent}%`);
-            prevPercent = percent;
-        }
-
+        const gradientStops = this.getBarColors().toGradientStops();
         shadyCss.styleSubtree(this, {
-            '--theoplayer-range-track-progress-internal': `linear-gradient(to right, ${gradientStops.join(', ')})`
+            '--theoplayer-range-track-progress-internal': `linear-gradient(to right, ${gradientStops})`
         });
     }
 
@@ -209,7 +200,7 @@ export abstract class Range extends HTMLElement {
      * Build the color gradient for the range bar.
      * Creating an array so progress-bar can insert the buffered bar.
      */
-    protected getBarColors(): Array<[string, number]> {
+    protected getBarColors(): ColorStops {
         const relativeValue = this.value - this.min;
         const relativeMax = this.max - this.min;
         const rangePercent = (relativeValue / relativeMax) * 100;
@@ -230,10 +221,9 @@ export abstract class Range extends HTMLElement {
             thumbPercent = (thumbOffset / this._lastRangeWidth) * 100;
         }
 
-        return [
-            ['var(--theoplayer-range-bar-color, #fff)', rangePercent + thumbPercent],
-            ['transparent', 100]
-        ];
+        const stops = new ColorStops();
+        stops.add('var(--theoplayer-range-bar-color, #fff)', 0, rangePercent + thumbPercent);
+        return stops;
     }
 
     private readonly _updatePointerBar = (e: PointerEvent): void => {

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -203,7 +203,10 @@ export abstract class Range extends HTMLElement {
     protected getBarColors(): ColorStops {
         const relativeValue = this.value - this.min;
         const relativeMax = this.max - this.min;
-        const rangePercent = (relativeValue / relativeMax) * 100;
+        let rangePercent = (relativeValue / relativeMax) * 100;
+        if (isNaN(rangePercent)) {
+            rangePercent = 0;
+        }
 
         // Use the last non-zero range width, in case the range is temporarily hidden.
         const rangeWidth = this._rangeEl.offsetWidth;

--- a/src/components/TextDisplay.css
+++ b/src/components/TextDisplay.css
@@ -1,9 +1,6 @@
 :host {
-    display: inline-flex;
+    display: inline-block;
     box-sizing: border-box;
-    align-items: center;
-    justify-content: center;
-    vertical-align: middle;
     pointer-events: auto;
     user-select: none;
     padding: var(--theoplayer-control-padding, 10px);
@@ -12,14 +9,11 @@
     color: var(--theoplayer-text-color, #fff);
     background: var(--theoplayer-control-background, transparent);
 
-    /* Vertically center any text */
-    font-size: var(--theoplayer-text-font-size, 14px);
-    line-height: var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px));
-}
-
-:host,
-span {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+
+    /* Vertically center any text */
+    font-size: var(--theoplayer-text-font-size, 14px);
+    line-height: var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px));
 }

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -21,7 +21,7 @@ shadyCss.prepareTemplate(template, 'theoplayer-time-range');
 
 const UPDATE_EVENTS = ['timeupdate', 'durationchange', 'ratechange', 'seeking', 'seeked'] as const;
 const AUTO_ADVANCE_EVENTS = ['play', 'pause', 'ended', 'readystatechange', 'error'] as const;
-const AD_EVENTS = ['adbreakbegin', 'adbreakend', 'adbreakchange', 'updateadbreak', 'adbegin', 'adend', 'addad', 'updatead'] as const;
+const AD_EVENTS = ['adbreakbegin', 'adbreakend', 'adbreakchange', 'updateadbreak', 'adbegin', 'adend', 'adskip', 'addad', 'updatead'] as const;
 const DEFAULT_MISSING_TIME_PHRASE = 'video not loaded, unknown time';
 
 /**

--- a/src/components/ads/AdClickThroughButton.ts
+++ b/src/components/ads/AdClickThroughButton.ts
@@ -24,6 +24,10 @@ export class AdClickThroughButton extends StateReceiverMixin(LinkButton, ['playe
 
     constructor() {
         super({ template });
+
+        this.disabled = true;
+        this.style.display = 'none';
+
         this._upgradeProperty('clickThrough');
         this._upgradeProperty('player');
     }

--- a/src/components/ads/AdClickThroughButton.ts
+++ b/src/components/ads/AdClickThroughButton.ts
@@ -94,6 +94,11 @@ export class AdClickThroughButton extends StateReceiverMixin(LinkButton, ['playe
             this.clickThrough = null;
             return;
         }
+        if (linearAd.integration === 'google-ima') {
+            // Google IMA always shows their own clickthrough button.
+            this.clickThrough = null;
+            return;
+        }
         const clickThrough = linearAd.clickThrough;
         if (!clickThrough) {
             // Linear ad has no clickthrough URL.

--- a/src/components/ads/AdDisplay.ts
+++ b/src/components/ads/AdDisplay.ts
@@ -10,7 +10,7 @@ const template = document.createElement('template');
 template.innerHTML = `<style>${textDisplayCss}\n${adDisplayCss}</style><span></span>`;
 shadyCss.prepareTemplate(template, 'theoplayer-ad-display');
 
-const AD_EVENTS = ['adbreakbegin', 'adbreakend', 'adbreakchange', 'updateadbreak', 'adbegin', 'adend', 'addad', 'updatead'] as const;
+const AD_EVENTS = ['adbreakbegin', 'adbreakend', 'adbreakchange', 'updateadbreak', 'adbegin', 'adend', 'adskip', 'addad', 'updatead'] as const;
 
 /**
  * @group Components

--- a/src/components/ads/AdSkipButton.ts
+++ b/src/components/ads/AdSkipButton.ts
@@ -95,7 +95,12 @@ export class AdSkipButton extends StateReceiverMixin(Button, ['player']) {
         }
         const linearAd = arrayFind(ads.currentAds ?? [], isLinearAd);
         if (linearAd === undefined) {
-            // No linear ad
+            // No linear ad.
+            this.style.display = 'none';
+            return;
+        }
+        if (linearAd.integration === 'google-ima') {
+            // Google IMA always shows their own skip button.
             this.style.display = 'none';
             return;
         }

--- a/src/util/Attribute.ts
+++ b/src/util/Attribute.ts
@@ -43,6 +43,7 @@ export enum Attribute {
     TRACK_TYPE = 'track-type',
     SHOW_OFF = 'show-off',
     PLAYING_AD = 'playing-ad',
+    SHOW_AD_MARKERS = 'show-ad-markers',
     CLICKTHROUGH = 'clickthrough',
     PROPERTY = 'property',
     VALUE = 'value'

--- a/src/util/ColorStops.ts
+++ b/src/util/ColorStops.ts
@@ -1,0 +1,56 @@
+import { arrayFindIndex } from './CommonUtils';
+
+export type ColorStop = [color: string, percent: number];
+
+export class ColorStops {
+    private _stops: ColorStop[] = [['transparent', 100]];
+
+    constructor() {}
+
+    add(color: string, from: number, to: number): void {
+        from = Math.max(from, 0);
+        to = Math.min(to, 100);
+        if (from >= to) {
+            return;
+        }
+        const previousIndex = arrayFindIndex(this._stops, ([, percent]) => from <= percent);
+        if (previousIndex < 0) {
+            return;
+        }
+        const [previousColor, previousPercent] = this._stops[previousIndex];
+        const newStops: ColorStop[] = [];
+        if (from > 0) {
+            newStops.push([previousColor, from]);
+        }
+        newStops.push([color, to]);
+        if (to < previousPercent) {
+            // New stop is fully contained within previous stop
+            // Split previous stop
+            newStops.push([previousColor, previousPercent]);
+            this._stops.splice(previousIndex, 1, ...newStops);
+        } else {
+            // New stop extends beyond previous stop
+            // Remove overlapping stops
+            let nextIndex = previousIndex + 1;
+            while (nextIndex < this._stops.length) {
+                if (to < this._stops[nextIndex][1]) {
+                    break;
+                }
+                nextIndex++;
+            }
+            this._stops.splice(previousIndex, nextIndex - previousIndex, ...newStops);
+        }
+    }
+
+    toGradientStops(): string {
+        const gradientStops: string[] = [];
+        let prevPercent = 0;
+        for (const [color, percent] of this._stops) {
+            if (percent < prevPercent) continue;
+            gradientStops.push(`${color} ${prevPercent}%`);
+            gradientStops.push(`${color} ${percent}%`);
+            prevPercent = percent;
+        }
+        return gradientStops.join(', ');
+    }
+}


### PR DESCRIPTION
This adds support for advertisements in the default UI, and polishes the existing ad components.

* `<theoplayer-time-range>` now has an extra `show-ad-markers` attribute. When set, yellow ad markers are shown on the progress bar to indicate when the content will be interrupted by an advertisement.
* While playing a Google IMA, `<theoplayer-ad-skip-button>` and `<theoplayer-ad-clickthrough-button>` are always hidden. This is necessary, because Google IMA doesn't provide a way to hide its own built-in buttons. Unfortunately, this means you can't use custom buttons for these when using IMA. 😞
* `<theoplayer-default-ui>` now has a reworked ad control bar, taking up less space and showing fewer controls. This is necessary to leave enough space for Google IMA's own buttons.
![ads-example](https://user-images.githubusercontent.com/649348/234044702-1f703267-33ca-4ad0-b9fa-092acb8f21ca.png)
