### PR TITLE
Import chromeless THEOplayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ## Unreleased
 
+-   💥 **Breaking Change**: This project now requires THEOplayer version 5.1.0 or higher.
+-   🏠 This project now depends on the chromeless version of THEOplayer, rather than the full version which includes the old video.js-based UI. ([#31](https://github.com/THEOplayer/web-ui/pull/31))
 -   🐛 Fix `has-error` attribute not cleared on source change ([#29](https://github.com/THEOplayer/web-ui/pull/29))
 
 ## v1.2.0 (2023-04-26)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "https://github.com/THEOplayer/web-ui.git"
   },
   "peerDependencies": {
-    "theoplayer": "^4 || ^5"
+    "theoplayer": "^5.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.2",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -20,6 +20,7 @@ const banner = `/*!
  * THEOplayer Web UI v${version}
  * License: ${license}
  */`;
+const theoplayerModule = 'theoplayer/THEOplayer.chromeless';
 
 export default defineConfig([
     {
@@ -33,7 +34,7 @@ export default defineConfig([
                 indent: false,
                 banner,
                 globals: {
-                    theoplayer: 'THEOplayer'
+                    [theoplayerModule]: 'THEOplayer'
                 }
             },
             {
@@ -44,7 +45,7 @@ export default defineConfig([
             }
         ],
         context: 'self',
-        external: ['theoplayer'],
+        external: [theoplayerModule],
         plugins: jsPlugins({ es5: false, production, sourcemap: true })
     },
     {
@@ -58,7 +59,7 @@ export default defineConfig([
                 indent: false,
                 banner,
                 globals: {
-                    theoplayer: 'THEOplayer'
+                    [theoplayerModule]: 'THEOplayer'
                 }
             },
             {
@@ -69,7 +70,7 @@ export default defineConfig([
             }
         ],
         context: 'self',
-        external: ['theoplayer'],
+        external: [theoplayerModule],
         plugins: jsPlugins({ es5: true, production, sourcemap: false })
     },
     {
@@ -83,7 +84,7 @@ export default defineConfig([
                 footer: `export as namespace ${umdName};`
             }
         ],
-        external: ['theoplayer'],
+        external: [theoplayerModule],
         plugins: [dts()]
     }
 ]);

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -1,5 +1,5 @@
 import * as shadyCss from '@webcomponents/shadycss';
-import type { ChromelessPlayer, PlayerConfiguration, SourceDescription } from 'theoplayer';
+import type { ChromelessPlayer, PlayerConfiguration, SourceDescription } from 'theoplayer/THEOplayer.chromeless';
 import type { UIContainer } from './UIContainer';
 import defaultUiCss from './DefaultUI.css';
 import defaultUiHtml from './DefaultUI.html';

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1,5 +1,11 @@
 import * as shadyCss from '@webcomponents/shadycss';
-import { ChromelessPlayer, type MediaTrack, type PlayerConfiguration, type SourceDescription, type VideoQuality } from 'theoplayer';
+import {
+    ChromelessPlayer,
+    type MediaTrack,
+    type PlayerConfiguration,
+    type SourceDescription,
+    type VideoQuality
+} from 'theoplayer/THEOplayer.chromeless';
 import elementCss from './UIContainer.css';
 import elementHtml from './UIContainer.html';
 import { arrayFind, arrayRemove, containsComposedNode, isElement, isHTMLElement, noOp } from './util/CommonUtils';

--- a/src/components/ActiveQualityDisplay.ts
+++ b/src/components/ActiveQualityDisplay.ts
@@ -1,6 +1,6 @@
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { setTextContent } from '../util/CommonUtils';
-import type { VideoQuality } from 'theoplayer';
+import type { VideoQuality } from 'theoplayer/THEOplayer.chromeless';
 import { formatQualityLabel } from '../util/TrackUtils';
 import * as shadyCss from '@webcomponents/shadycss';
 

--- a/src/components/AirPlayButton.ts
+++ b/src/components/AirPlayButton.ts
@@ -1,5 +1,5 @@
 import * as shadyCss from '@webcomponents/shadycss';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { CastButton } from './CastButton';
 import airPlayButtonHtml from './AirPlayButton.html';

--- a/src/components/CastButton.ts
+++ b/src/components/CastButton.ts
@@ -1,6 +1,6 @@
 import { Button, type ButtonOptions } from './Button';
 import { Attribute } from '../util/Attribute';
-import type { CastState, VendorCast } from 'theoplayer';
+import type { CastState, VendorCast } from 'theoplayer/THEOplayer.chromeless';
 import * as shadyCss from '@webcomponents/shadycss';
 
 /**

--- a/src/components/ChromecastButton.ts
+++ b/src/components/ChromecastButton.ts
@@ -1,5 +1,5 @@
 import * as shadyCss from '@webcomponents/shadycss';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { CastButton } from './CastButton';
 import chromecastButtonHtml from './ChromecastButton.html';

--- a/src/components/ChromecastDisplay.ts
+++ b/src/components/ChromecastDisplay.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import chromecastDisplayCss from './ChromecastDisplay.css';
 import chromecastIcon from '../icons/chromecast-48px.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/DurationDisplay.ts
+++ b/src/components/DurationDisplay.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from './TextDisplay.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { formatTime } from '../util/TimeUtils';
 import { Attribute } from '../util/Attribute';

--- a/src/components/ErrorDisplay.ts
+++ b/src/components/ErrorDisplay.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import errorDisplayCss from './ErrorDisplay.css';
 import errorIcon from '../icons/error.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { THEOplayerError } from 'theoplayer';
+import type { THEOplayerError } from 'theoplayer/THEOplayer.chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/GestureReceiver.ts
+++ b/src/components/GestureReceiver.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import gestureReceiverCss from './GestureReceiver.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${gestureReceiverCss}</style>`;

--- a/src/components/LanguageMenu.ts
+++ b/src/components/LanguageMenu.ts
@@ -3,7 +3,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import languageMenuHtml from './LanguageMenu.html';
 import languageMenuCss from './LanguageMenu.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, MediaTrack, TextTrack } from 'theoplayer';
+import type { ChromelessPlayer, MediaTrack, TextTrack } from 'theoplayer/THEOplayer.chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 import './TrackRadioGroup';

--- a/src/components/LanguageMenuButton.ts
+++ b/src/components/LanguageMenuButton.ts
@@ -3,7 +3,7 @@ import { buttonTemplate } from './Button';
 import languageIcon from '../icons/language.svg';
 import * as shadyCss from '@webcomponents/shadycss';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/LiveButton.ts
+++ b/src/components/LiveButton.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import liveButtonCss from './LiveButton.css';
 import liveIcon from '../icons/live.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';

--- a/src/components/LoadingIndicator.ts
+++ b/src/components/LoadingIndicator.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import loadingIndicatorCss from './LoadingIndicator.css';
 import loadingIndicatorHtml from './LoadingIndicator.html';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { Attribute } from '../util/Attribute';
 
 const template = document.createElement('template');

--- a/src/components/MediaTrackRadioButton.ts
+++ b/src/components/MediaTrackRadioButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
-import type { MediaTrack } from 'theoplayer';
+import type { MediaTrack } from 'theoplayer/THEOplayer.chromeless';
 import { localizeLanguageName, setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/MuteButton.ts
+++ b/src/components/MuteButton.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import muteButtonCss from './MuteButton.css';
 import offIcon from '../icons/volume-off.svg';
 import lowIcon from '../icons/volume-low.svg';

--- a/src/components/PlayButton.ts
+++ b/src/components/PlayButton.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import playButtonCss from './PlayButton.css';
 import playIcon from '../icons/play.svg';
 import pauseIcon from '../icons/pause.svg';

--- a/src/components/PlaybackRateRadioGroup.ts
+++ b/src/components/PlaybackRateRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import type { RadioButton } from './RadioButton';
 import { createEvent } from '../util/EventUtils';
 

--- a/src/components/PreviewThumbnail.ts
+++ b/src/components/PreviewThumbnail.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import previewThumbnailCss from './PreviewThumbnail.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, TextTrack, TextTrackCue, TextTrackCueList } from 'theoplayer';
+import type { ChromelessPlayer, TextTrack, TextTrackCue, TextTrackCueList } from 'theoplayer/THEOplayer.chromeless';
 import { arrayFind, noOp } from '../util/CommonUtils';
 
 const template = document.createElement('template');

--- a/src/components/PreviewTimeDisplay.ts
+++ b/src/components/PreviewTimeDisplay.ts
@@ -4,7 +4,7 @@ import { StateReceiverMixin } from './StateReceiverMixin';
 import { setTextContent } from '../util/CommonUtils';
 import { formatTime } from '../util/TimeUtils';
 import { Attribute } from '../util/Attribute';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import type { StreamType } from '../util/StreamType';
 
 const template = document.createElement('template');

--- a/src/components/QualityRadioButton.ts
+++ b/src/components/QualityRadioButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
-import type { MediaTrack, VideoQuality } from 'theoplayer';
+import type { MediaTrack, VideoQuality } from 'theoplayer/THEOplayer.chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 import { formatQualityLabel } from '../util/TrackUtils';

--- a/src/components/QualityRadioGroup.ts
+++ b/src/components/QualityRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, MediaTrack, Quality, VideoQuality } from 'theoplayer';
+import type { ChromelessPlayer, MediaTrack, Quality, VideoQuality } from 'theoplayer/THEOplayer.chromeless';
 import { arrayFind, fromArrayLike } from '../util/CommonUtils';
 import { QualityRadioButton } from './QualityRadioButton';
 import { createEvent } from '../util/EventUtils';

--- a/src/components/SeekButton.ts
+++ b/src/components/SeekButton.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import seekButtonCss from './SeekButton.css';
 import seekForwardIcon from '../icons/seek-forward.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';

--- a/src/components/StateReceiverMixin.ts
+++ b/src/components/StateReceiverMixin.ts
@@ -1,5 +1,5 @@
 import { type Constructor, fromArrayLike, isArray, isElement, isHTMLElement, isHTMLSlotElement } from '../util/CommonUtils';
-import type { ChromelessPlayer, THEOplayerError, VideoQuality } from 'theoplayer';
+import type { ChromelessPlayer, THEOplayerError, VideoQuality } from 'theoplayer/THEOplayer.chromeless';
 import type { StreamType } from '../util/StreamType';
 
 /** @internal */

--- a/src/components/TextTrackOffRadioButton.ts
+++ b/src/components/TextTrackOffRadioButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
-import type { TextTracksList } from 'theoplayer';
+import type { TextTracksList } from 'theoplayer/THEOplayer.chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/TextTrackRadioButton.ts
+++ b/src/components/TextTrackRadioButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
-import type { TextTrack } from 'theoplayer';
+import type { TextTrack } from 'theoplayer/THEOplayer.chromeless';
 import { localizeLanguageName, setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/TextTrackStyleDisplay.ts
+++ b/src/components/TextTrackStyleDisplay.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, EdgeStyle } from 'theoplayer';
+import type { ChromelessPlayer, EdgeStyle } from 'theoplayer/THEOplayer.chromeless';
 import { Attribute } from '../util/Attribute';
 import { parseColor, toRgb } from '../util/ColorUtils';
 import type { TextTrackStyleOption } from './TextTrackStyleRadioGroup';

--- a/src/components/TextTrackStyleRadioGroup.ts
+++ b/src/components/TextTrackStyleRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, EdgeStyle } from 'theoplayer';
+import type { ChromelessPlayer, EdgeStyle } from 'theoplayer/THEOplayer.chromeless';
 import type { RadioButton } from './RadioButton';
 import { createEvent } from '../util/EventUtils';
 import { Attribute } from '../util/Attribute';

--- a/src/components/TextTrackStyleResetButton.ts
+++ b/src/components/TextTrackStyleResetButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 
 const template = document.createElement('template');
 template.innerHTML = buttonTemplate(`<slot>Reset</slot>`);

--- a/src/components/TimeDisplay.ts
+++ b/src/components/TimeDisplay.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from './TextDisplay.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { formatAsTimePhrase, formatTime } from '../util/TimeUtils';
 import { Attribute } from '../util/Attribute';

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -3,7 +3,7 @@ import { Range, rangeTemplate } from './Range';
 import timeRangeHtml from './TimeRange.html';
 import timeRangeCss from './TimeRange.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { formatAsTimePhrase } from '../util/TimeUtils';
 import { createCustomEvent } from '../util/EventUtils';
 import type { PreviewTimeChangeEvent } from '../events/PreviewTimeChangeEvent';

--- a/src/components/TrackRadioGroup.ts
+++ b/src/components/TrackRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, MediaTrack, MediaTrackList, TextTrack, TextTracksList } from 'theoplayer';
+import type { ChromelessPlayer, MediaTrack, MediaTrackList, TextTrack, TextTracksList } from 'theoplayer/THEOplayer.chromeless';
 import { Attribute } from '../util/Attribute';
 import { MediaTrackRadioButton } from './MediaTrackRadioButton';
 import { TextTrackRadioButton } from './TextTrackRadioButton';

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Range, rangeTemplate } from './Range';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 
 const template = document.createElement('template');
 template.innerHTML = rangeTemplate(`<input type="range" min="0" max="1" step="any" value="0">`);

--- a/src/components/ads/AdClickThroughButton.ts
+++ b/src/components/ads/AdClickThroughButton.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { LinkButton, linkButtonTemplate } from '../LinkButton';
 import { StateReceiverMixin } from '../StateReceiverMixin';
 import { Attribute } from '../../util/Attribute';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { arrayFind } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 

--- a/src/components/ads/AdCountdown.ts
+++ b/src/components/ads/AdCountdown.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from '../TextDisplay.css';
 import adCountdownCss from './AdCountdown.css';
 import { StateReceiverMixin } from '../StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { setTextContent } from '../../util/CommonUtils';
 
 const template = document.createElement('template');

--- a/src/components/ads/AdDisplay.ts
+++ b/src/components/ads/AdDisplay.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from '../TextDisplay.css';
 import adDisplayCss from './AdDisplay.css';
 import { StateReceiverMixin } from '../StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { arrayFind, setTextContent } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 

--- a/src/components/ads/AdSkipButton.ts
+++ b/src/components/ads/AdSkipButton.ts
@@ -4,7 +4,7 @@ import adSkipButtonCss from './AdSkipButton.css';
 import skipNextIcon from '../../icons/skip-next.svg';
 import { StateReceiverMixin } from '../StateReceiverMixin';
 import { Attribute } from '../../util/Attribute';
-import type { ChromelessPlayer } from 'theoplayer';
+import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
 import { arrayFind, setTextContent } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 

--- a/src/util/AdUtils.ts
+++ b/src/util/AdUtils.ts
@@ -1,4 +1,4 @@
-import type { Ad } from 'theoplayer';
+import type { Ad } from 'theoplayer/THEOplayer.chromeless';
 
 export function isLinearAd(ad: Ad): boolean {
     return ad.type === 'linear';

--- a/src/util/TextTrackStylePresets.ts
+++ b/src/util/TextTrackStylePresets.ts
@@ -1,4 +1,4 @@
-import type { EdgeStyle } from 'theoplayer';
+import type { EdgeStyle } from 'theoplayer/THEOplayer.chromeless';
 
 export const knownColors: ReadonlyArray<[string, string]> = [
     ['White', 'rgb(255,255,255)'],

--- a/src/util/TrackUtils.ts
+++ b/src/util/TrackUtils.ts
@@ -1,4 +1,4 @@
-import type { MediaTrack, Quality, TextTrack, VideoQuality } from 'theoplayer';
+import type { MediaTrack, Quality, TextTrack, VideoQuality } from 'theoplayer/THEOplayer.chromeless';
 
 export function isSubtitleTrack(track: TextTrack): boolean {
     return track.kind === 'subtitles' || track.kind === 'captions';


### PR DESCRIPTION
Previously, we used `import {/*...*/} from 'theoplayer'`, which would import the full THEOplayer library including the old video.js-based UI. Since we only need the chromeless player library (without UI) in this project, we now import from `'theoplayer/THEOplayer.chromeless'` instead.

This is a (small) breaking change for TypeScript users. `THEOplayer.chromeless.js` has always been packaged together with the `theoplayer` npm package, but we only recently (as of version 5.1.0) also ship dedicated TypeScript type definitions for this file. Therefore, TypeScript users will need to update to the latest version of THEOplayer.