### PR TITLE
Use JavaScript modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 > -   🏠 Internal
 > -   💅 Polish
 
+## Unreleased
+
+-   💥 **Breaking Change**: This project now requires THEOplayer version 6.0.0 or higher.
+-   🚀 THEOplayer Web UI now imports THEOplayer as a JavaScript module using `import from 'theoplayer/chromeless'`.
+    See the [README](./README.md#installation) for updated installation instructions.
+
 ## v1.3.0 (2023-05-16)
 
 -   💥 **Breaking Change**: This project now requires THEOplayer version 5.1.0 or higher.

--- a/README.md
+++ b/README.md
@@ -132,12 +132,20 @@ On older browsers (such as Internet Explorer 11 and older smart TVs), you need t
 -   Option 1: in your HTML. This uses [differential serving](https://css-tricks.com/differential-serving/) so modern browsers will load the modern build (with `type="module"`, while legacy browsers will load the legacy build (with `nomodule`).
 
     ```html
-    <!-- Load polyfills -->
+    <!-- Modern browsers -->
+    <script type="importmap">
+    {
+      "imports": {
+        "theoplayer/chromeless": "/path/to/node_modules/theoplayer/THEOplayer.chromeless.esm.js"
+      }
+    }
+    </script>
+    <script type="module" src="/path/to/node_modules/@theoplayer/web-ui/dist/THEOplayerUI.mjs"></script>
+    <!-- Legacy browsers -->
     <script nomodule src="https://polyfill.io/v3/polyfill.min.js?features=es2015"></script>
     <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/custom-elements-es5-adapter.js"></script>
     <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/webcomponents-bundle.js"></script>
-    <!-- Load modern or legacy build -->
-    <script type="module" src="/path/to/node_modules/@theoplayer/web-ui/dist/THEOplayerUI.js"></script>
+    <script nomodule src="/path/to/node_modules/theoplayer/THEOplayer.chromeless.js"></script>
     <script nomodule src="/path/to/node_modules/@theoplayer/web-ui/dist/THEOplayerUI.es5.js"></script>
     ```
 

--- a/README.md
+++ b/README.md
@@ -49,16 +49,16 @@ The current THEOplayer Web SDK comes with a built-in UI based on [video.js](http
         ```js
         import { DefaultUI } from '@theoplayer/web-ui';
         ```
-      The Web UI will import THEOplayer from `theoplayer/chromeless`.
-      If you're using a bundler such as Webpack or Rollup, this dependency should automatically get bundled with your web app.
-      Alternatively, you can use an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) to let the browser resolve it:
+        The Web UI will import THEOplayer from `theoplayer/chromeless`.
+        If you're using a bundler such as Webpack or Rollup, this dependency should automatically get bundled with your web app.
+        Alternatively, you can use an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) to let the browser resolve it:
         ```html
         <script type="importmap">
-        {
-          "imports": {
-            "theoplayer/chromeless": "/path/to/node_modules/theoplayer/THEOplayer.chromeless.esm.js"
-          }
-        }
+            {
+                "imports": {
+                    "theoplayer/chromeless": "/path/to/node_modules/theoplayer/THEOplayer.chromeless.esm.js"
+                }
+            }
         </script>
         <script type="module" src="/path/to/my_app.js"></script>
         ```
@@ -134,11 +134,11 @@ On older browsers (such as Internet Explorer 11 and older smart TVs), you need t
     ```html
     <!-- Modern browsers -->
     <script type="importmap">
-    {
-      "imports": {
-        "theoplayer/chromeless": "/path/to/node_modules/theoplayer/THEOplayer.chromeless.esm.js"
-      }
-    }
+        {
+            "imports": {
+                "theoplayer/chromeless": "/path/to/node_modules/theoplayer/THEOplayer.chromeless.esm.js"
+            }
+        }
     </script>
     <script type="module" src="/path/to/node_modules/@theoplayer/web-ui/dist/THEOplayerUI.mjs"></script>
     <!-- Legacy browsers -->

--- a/README.md
+++ b/README.md
@@ -42,15 +42,26 @@ The current THEOplayer Web SDK comes with a built-in UI based on [video.js](http
 3. Add `@theoplayer/web-ui` to your app:
     - Option 1: in your HTML.
         ```html
+        <script src="/path/to/node_modules/theoplayer/THEOplayer.chromeless.js"></script>
         <script src="/path/to/node_modules/@theoplayer/web-ui/dist/THEOplayerUI.js"></script>
         ```
     - Option 2: in your JavaScript.
         ```js
         import { DefaultUI } from '@theoplayer/web-ui';
         ```
-
-> **Warning**
-> THEOplayer Web SDK currently only supports being loaded through a regular `<script>` tag or as a [UMD module](https://github.com/umdjs/umd), and does not support being `import`ed as a native JavaScript module. If you use `import` with THEOplayer Web UI, make sure to use a JavaScript bundler such as Webpack or Rollup to include THEOplayer in your app. We're hoping to fix this incompatibility soon.
+      The Web UI will import THEOplayer from `theoplayer/chromeless`.
+      If you're using a bundler such as Webpack or Rollup, this dependency should automatically get bundled with your web app.
+      Alternatively, you can use an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) to let the browser resolve it:
+        ```html
+        <script type="importmap">
+        {
+          "imports": {
+            "theoplayer/chromeless": "/path/to/node_modules/theoplayer/THEOplayer.chromeless.esm.js"
+          }
+        }
+        </script>
+        <script type="module" src="/path/to/my_app.js"></script>
+        ```
 
 ## Usage
 

--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -16,7 +16,7 @@ layout: page
 <script type="importmap">
     {
         "imports": {
-            "theoplayer/THEOplayer.chromeless": "https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.esm.js"
+            "theoplayer/chromeless": "https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.esm.js"
         }
     }
 </script>

--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -16,7 +16,7 @@ layout: page
 <script type="importmap">
     {
         "imports": {
-            "theoplayer/THEOplayer.chromeless": "https://unpkg.com/theoplayer@6/THEOplayer.chromeless.esm.js"
+            "theoplayer/THEOplayer.chromeless": "https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.esm.js"
         }
     }
 </script>
@@ -25,7 +25,7 @@ layout: page
 <script nomodule src="https://polyfill.io/v3/polyfill.min.js?features=es2015"></script>
 <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/custom-elements-es5-adapter.js"></script>
 <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/webcomponents-bundle.js"></script>
-<script nomodule src="https://unpkg.com/theoplayer@6/THEOplayer.chromeless.js"></script>
+<script nomodule src="https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.js"></script>
 <script nomodule src="../dist/THEOplayerUI.es5.js"></script>
 
 {{ content }}

--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -12,12 +12,6 @@ layout: page
         background: #000;
     }
 </style>
-<!-- Legacy browsers -->
-<script nomodule src="https://polyfill.io/v3/polyfill.min.js?features=es2015"></script>
-<script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/custom-elements-es5-adapter.js"></script>
-<script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/webcomponents-bundle.js"></script>
-<script nomodule src="https://unpkg.com/theoplayer@6/THEOplayer.chromeless.js"></script>
-<script nomodule src="../dist/THEOplayerUI.es5.js"></script>
 <!-- Modern browsers -->
 <script type="importmap">
     {
@@ -27,5 +21,11 @@ layout: page
     }
 </script>
 <script type="module" src="../dist/THEOplayerUI.mjs"></script>
+<!-- Legacy browsers -->
+<script nomodule src="https://polyfill.io/v3/polyfill.min.js?features=es2015"></script>
+<script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/custom-elements-es5-adapter.js"></script>
+<script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/webcomponents-bundle.js"></script>
+<script nomodule src="https://unpkg.com/theoplayer@6/THEOplayer.chromeless.js"></script>
+<script nomodule src="../dist/THEOplayerUI.es5.js"></script>
 
 {{ content }}

--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -12,11 +12,20 @@ layout: page
         background: #000;
     }
 </style>
+<!-- Legacy browsers -->
 <script nomodule src="https://polyfill.io/v3/polyfill.min.js?features=es2015"></script>
 <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/custom-elements-es5-adapter.js"></script>
 <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/webcomponents-bundle.js"></script>
-<script src="https://unpkg.com/theoplayer@6/THEOplayer.chromeless.js"></script>
-<script type="module" src="../dist/THEOplayerUI.js"></script>
+<script nomodule src="https://unpkg.com/theoplayer@6/THEOplayer.chromeless.js"></script>
 <script nomodule src="../dist/THEOplayerUI.es5.js"></script>
+<!-- Modern browsers -->
+<script type="importmap">
+    {
+        "imports": {
+            "theoplayer/THEOplayer.chromeless": "https://unpkg.com/theoplayer@6/THEOplayer.chromeless.esm.js"
+        }
+    }
+</script>
+<script type="module" src="../dist/THEOplayerUI.mjs"></script>
 
 {{ content }}

--- a/docs/examples/ads.html
+++ b/docs/examples/ads.html
@@ -11,7 +11,10 @@ permalink: /examples/ads
     }
 </style>
 
-<theoplayer-default-ui configuration='{"libraryLocation":"https://unpkg.com/theoplayer@6/","license":"{{ site.theoplayer_license }}"}' fluid>
+<theoplayer-default-ui
+    configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","license":"{{ site.theoplayer_license }}"}'
+    fluid
+>
     <span slot="title">Elephant's Dream</span>
 </theoplayer-default-ui>
 <p>

--- a/docs/examples/custom-ui.html
+++ b/docs/examples/custom-ui.html
@@ -63,7 +63,7 @@ permalink: /examples/custom-ui
 </style>
 
 <theoplayer-ui
-    configuration='{"libraryLocation":"https://unpkg.com/theoplayer@6/","license":"{{ site.theoplayer_license }}"}'
+    configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","license":"{{ site.theoplayer_license }}"}'
     source='{"sources":"https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)"}'
     fluid
 >

--- a/docs/examples/default-ui.html
+++ b/docs/examples/default-ui.html
@@ -12,7 +12,7 @@ permalink: /examples/default-ui
 </style>
 
 <theoplayer-default-ui
-    configuration='{"libraryLocation":"https://unpkg.com/theoplayer@6/","license":"{{ site.theoplayer_license }}"}'
+    configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","license":"{{ site.theoplayer_license }}"}'
     source='{"sources":"https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)"}'
     fluid
 >

--- a/docs/examples/nitflex.html
+++ b/docs/examples/nitflex.html
@@ -7,7 +7,7 @@ permalink: /examples/nitflex
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Sharp:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
 <link href="nitflex.css" rel="stylesheet" />
 <theoplayer-ui
-    configuration='{"libraryLocation":"https://unpkg.com/theoplayer@6/","license":"{{ site.theoplayer_license }}"}'
+    configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","license":"{{ site.theoplayer_license }}"}'
     source='{"sources":"https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)"}'
     fluid
 >

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "theoplayer": "^5.1.0 || ^6"
+        "theoplayer": "^6"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "url": "https://github.com/THEOplayer/web-ui.git"
   },
   "peerDependencies": {
-    "theoplayer": "^5.1.0 || ^6"
+    "theoplayer": "^6"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.2",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -21,7 +21,7 @@ const banner = `/*!
  * THEOplayer Web UI v${version}
  * License: ${license}
  */`;
-const theoplayerModule = 'theoplayer/THEOplayer.chromeless';
+const theoplayerModule = 'theoplayer/chromeless';
 
 /**
  * @param {{configOutputDir?: string}} cliArgs

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -1,5 +1,5 @@
 import * as shadyCss from '@webcomponents/shadycss';
-import type { ChromelessPlayer, PlayerConfiguration, SourceDescription } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer, PlayerConfiguration, SourceDescription } from 'theoplayer/chromeless';
 import type { UIContainer } from './UIContainer';
 import defaultUiCss from './DefaultUI.css';
 import defaultUiHtml from './DefaultUI.html';

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1,11 +1,5 @@
 import * as shadyCss from '@webcomponents/shadycss';
-import {
-    ChromelessPlayer,
-    type MediaTrack,
-    type PlayerConfiguration,
-    type SourceDescription,
-    type VideoQuality
-} from 'theoplayer/THEOplayer.chromeless';
+import { ChromelessPlayer, type MediaTrack, type PlayerConfiguration, type SourceDescription, type VideoQuality } from 'theoplayer/chromeless';
 import elementCss from './UIContainer.css';
 import elementHtml from './UIContainer.html';
 import { arrayFind, arrayRemove, containsComposedNode, isElement, isHTMLElement, noOp } from './util/CommonUtils';

--- a/src/components/ActiveQualityDisplay.ts
+++ b/src/components/ActiveQualityDisplay.ts
@@ -1,6 +1,6 @@
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { setTextContent } from '../util/CommonUtils';
-import type { VideoQuality } from 'theoplayer/THEOplayer.chromeless';
+import type { VideoQuality } from 'theoplayer/chromeless';
 import { formatQualityLabel } from '../util/TrackUtils';
 import * as shadyCss from '@webcomponents/shadycss';
 

--- a/src/components/AirPlayButton.ts
+++ b/src/components/AirPlayButton.ts
@@ -1,5 +1,5 @@
 import * as shadyCss from '@webcomponents/shadycss';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { CastButton } from './CastButton';
 import airPlayButtonHtml from './AirPlayButton.html';

--- a/src/components/CastButton.ts
+++ b/src/components/CastButton.ts
@@ -1,6 +1,6 @@
 import { Button, type ButtonOptions } from './Button';
 import { Attribute } from '../util/Attribute';
-import type { CastState, VendorCast } from 'theoplayer/THEOplayer.chromeless';
+import type { CastState, VendorCast } from 'theoplayer/chromeless';
 import * as shadyCss from '@webcomponents/shadycss';
 
 /**

--- a/src/components/ChromecastButton.ts
+++ b/src/components/ChromecastButton.ts
@@ -1,5 +1,5 @@
 import * as shadyCss from '@webcomponents/shadycss';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { CastButton } from './CastButton';
 import chromecastButtonHtml from './ChromecastButton.html';

--- a/src/components/ChromecastDisplay.ts
+++ b/src/components/ChromecastDisplay.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import chromecastDisplayCss from './ChromecastDisplay.css';
 import chromecastIcon from '../icons/chromecast-48px.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/DurationDisplay.ts
+++ b/src/components/DurationDisplay.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from './TextDisplay.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { formatTime } from '../util/TimeUtils';
 import { Attribute } from '../util/Attribute';

--- a/src/components/ErrorDisplay.ts
+++ b/src/components/ErrorDisplay.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import errorDisplayCss from './ErrorDisplay.css';
 import errorIcon from '../icons/error.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { THEOplayerError } from 'theoplayer/THEOplayer.chromeless';
+import type { THEOplayerError } from 'theoplayer/chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/GestureReceiver.ts
+++ b/src/components/GestureReceiver.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import gestureReceiverCss from './GestureReceiver.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${gestureReceiverCss}</style>`;

--- a/src/components/LanguageMenu.ts
+++ b/src/components/LanguageMenu.ts
@@ -3,7 +3,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import languageMenuHtml from './LanguageMenu.html';
 import languageMenuCss from './LanguageMenu.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, MediaTrack, TextTrack } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer, MediaTrack, TextTrack } from 'theoplayer/chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 import './TrackRadioGroup';

--- a/src/components/LanguageMenuButton.ts
+++ b/src/components/LanguageMenuButton.ts
@@ -3,7 +3,7 @@ import { buttonTemplate } from './Button';
 import languageIcon from '../icons/language.svg';
 import * as shadyCss from '@webcomponents/shadycss';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/LiveButton.ts
+++ b/src/components/LiveButton.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import liveButtonCss from './LiveButton.css';
 import liveIcon from '../icons/live.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';

--- a/src/components/LoadingIndicator.ts
+++ b/src/components/LoadingIndicator.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import loadingIndicatorCss from './LoadingIndicator.css';
 import loadingIndicatorHtml from './LoadingIndicator.html';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { Attribute } from '../util/Attribute';
 
 const template = document.createElement('template');

--- a/src/components/MediaTrackRadioButton.ts
+++ b/src/components/MediaTrackRadioButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
-import type { MediaTrack } from 'theoplayer/THEOplayer.chromeless';
+import type { MediaTrack } from 'theoplayer/chromeless';
 import { localizeLanguageName, setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/MuteButton.ts
+++ b/src/components/MuteButton.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import muteButtonCss from './MuteButton.css';
 import offIcon from '../icons/volume-off.svg';
 import lowIcon from '../icons/volume-low.svg';

--- a/src/components/PlayButton.ts
+++ b/src/components/PlayButton.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import playButtonCss from './PlayButton.css';
 import playIcon from '../icons/play.svg';
 import pauseIcon from '../icons/pause.svg';

--- a/src/components/PlaybackRateRadioGroup.ts
+++ b/src/components/PlaybackRateRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import type { RadioButton } from './RadioButton';
 import { createEvent } from '../util/EventUtils';
 

--- a/src/components/PreviewThumbnail.ts
+++ b/src/components/PreviewThumbnail.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import previewThumbnailCss from './PreviewThumbnail.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, TextTrack, TextTrackCue, TextTrackCueList } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer, TextTrack, TextTrackCue, TextTrackCueList } from 'theoplayer/chromeless';
 import { arrayFind, noOp } from '../util/CommonUtils';
 
 const template = document.createElement('template');

--- a/src/components/PreviewTimeDisplay.ts
+++ b/src/components/PreviewTimeDisplay.ts
@@ -4,7 +4,7 @@ import { StateReceiverMixin } from './StateReceiverMixin';
 import { setTextContent } from '../util/CommonUtils';
 import { formatTime } from '../util/TimeUtils';
 import { Attribute } from '../util/Attribute';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import type { StreamType } from '../util/StreamType';
 
 const template = document.createElement('template');

--- a/src/components/QualityRadioButton.ts
+++ b/src/components/QualityRadioButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
-import type { MediaTrack, VideoQuality } from 'theoplayer/THEOplayer.chromeless';
+import type { MediaTrack, VideoQuality } from 'theoplayer/chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 import { formatQualityLabel } from '../util/TrackUtils';

--- a/src/components/QualityRadioGroup.ts
+++ b/src/components/QualityRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, MediaTrack, Quality, VideoQuality } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer, MediaTrack, Quality, VideoQuality } from 'theoplayer/chromeless';
 import { arrayFind, fromArrayLike } from '../util/CommonUtils';
 import { QualityRadioButton } from './QualityRadioButton';
 import { createEvent } from '../util/EventUtils';

--- a/src/components/SeekButton.ts
+++ b/src/components/SeekButton.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import seekButtonCss from './SeekButton.css';
 import seekForwardIcon from '../icons/seek-forward.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';

--- a/src/components/StateReceiverMixin.ts
+++ b/src/components/StateReceiverMixin.ts
@@ -1,5 +1,5 @@
 import { type Constructor, fromArrayLike, isArray, isElement, isHTMLElement, isHTMLSlotElement } from '../util/CommonUtils';
-import type { ChromelessPlayer, THEOplayerError, VideoQuality } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer, THEOplayerError, VideoQuality } from 'theoplayer/chromeless';
 import type { StreamType } from '../util/StreamType';
 
 /** @internal */

--- a/src/components/TextTrackOffRadioButton.ts
+++ b/src/components/TextTrackOffRadioButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
-import type { TextTracksList } from 'theoplayer/THEOplayer.chromeless';
+import type { TextTracksList } from 'theoplayer/chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/TextTrackRadioButton.ts
+++ b/src/components/TextTrackRadioButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
-import type { TextTrack } from 'theoplayer/THEOplayer.chromeless';
+import type { TextTrack } from 'theoplayer/chromeless';
 import { localizeLanguageName, setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 

--- a/src/components/TextTrackStyleDisplay.ts
+++ b/src/components/TextTrackStyleDisplay.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, EdgeStyle } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer, EdgeStyle } from 'theoplayer/chromeless';
 import { Attribute } from '../util/Attribute';
 import { parseColor, toRgb } from '../util/ColorUtils';
 import type { TextTrackStyleOption } from './TextTrackStyleRadioGroup';

--- a/src/components/TextTrackStyleRadioGroup.ts
+++ b/src/components/TextTrackStyleRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, EdgeStyle } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer, EdgeStyle } from 'theoplayer/chromeless';
 import type { RadioButton } from './RadioButton';
 import { createEvent } from '../util/EventUtils';
 import { Attribute } from '../util/Attribute';

--- a/src/components/TextTrackStyleResetButton.ts
+++ b/src/components/TextTrackStyleResetButton.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Button, buttonTemplate } from './Button';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 
 const template = document.createElement('template');
 template.innerHTML = buttonTemplate(`<slot>Reset</slot>`);

--- a/src/components/TimeDisplay.ts
+++ b/src/components/TimeDisplay.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from './TextDisplay.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { formatAsTimePhrase, formatTime } from '../util/TimeUtils';
 import { Attribute } from '../util/Attribute';

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -3,7 +3,7 @@ import { Range, rangeTemplate } from './Range';
 import timeRangeHtml from './TimeRange.html';
 import timeRangeCss from './TimeRange.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { formatAsTimePhrase } from '../util/TimeUtils';
 import { createCustomEvent } from '../util/EventUtils';
 import type { PreviewTimeChangeEvent } from '../events/PreviewTimeChangeEvent';

--- a/src/components/TrackRadioGroup.ts
+++ b/src/components/TrackRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, MediaTrack, MediaTrackList, TextTrack, TextTracksList } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer, MediaTrack, MediaTrackList, TextTrack, TextTracksList } from 'theoplayer/chromeless';
 import { Attribute } from '../util/Attribute';
 import { MediaTrackRadioButton } from './MediaTrackRadioButton';
 import { TextTrackRadioButton } from './TextTrackRadioButton';

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Range, rangeTemplate } from './Range';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 
 const template = document.createElement('template');
 template.innerHTML = rangeTemplate(`<input type="range" min="0" max="1" step="any" value="0">`);

--- a/src/components/ads/AdClickThroughButton.ts
+++ b/src/components/ads/AdClickThroughButton.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { LinkButton, linkButtonTemplate } from '../LinkButton';
 import { StateReceiverMixin } from '../StateReceiverMixin';
 import { Attribute } from '../../util/Attribute';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { arrayFind } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 

--- a/src/components/ads/AdCountdown.ts
+++ b/src/components/ads/AdCountdown.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from '../TextDisplay.css';
 import adCountdownCss from './AdCountdown.css';
 import { StateReceiverMixin } from '../StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { setTextContent } from '../../util/CommonUtils';
 
 const template = document.createElement('template');

--- a/src/components/ads/AdDisplay.ts
+++ b/src/components/ads/AdDisplay.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from '../TextDisplay.css';
 import adDisplayCss from './AdDisplay.css';
 import { StateReceiverMixin } from '../StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { arrayFind, setTextContent } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 

--- a/src/components/ads/AdSkipButton.ts
+++ b/src/components/ads/AdSkipButton.ts
@@ -4,7 +4,7 @@ import adSkipButtonCss from './AdSkipButton.css';
 import skipNextIcon from '../../icons/skip-next.svg';
 import { StateReceiverMixin } from '../StateReceiverMixin';
 import { Attribute } from '../../util/Attribute';
-import type { ChromelessPlayer } from 'theoplayer/THEOplayer.chromeless';
+import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { arrayFind, setTextContent } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 

--- a/src/util/AdUtils.ts
+++ b/src/util/AdUtils.ts
@@ -1,4 +1,4 @@
-import type { Ad } from 'theoplayer/THEOplayer.chromeless';
+import type { Ad } from 'theoplayer/chromeless';
 
 export function isLinearAd(ad: Ad): boolean {
     return ad.type === 'linear';

--- a/src/util/TextTrackStylePresets.ts
+++ b/src/util/TextTrackStylePresets.ts
@@ -1,4 +1,4 @@
-import type { EdgeStyle } from 'theoplayer/THEOplayer.chromeless';
+import type { EdgeStyle } from 'theoplayer/chromeless';
 
 export const knownColors: ReadonlyArray<[string, string]> = [
     ['White', 'rgb(255,255,255)'],

--- a/src/util/TrackUtils.ts
+++ b/src/util/TrackUtils.ts
@@ -1,4 +1,4 @@
-import type { MediaTrack, Quality, TextTrack, VideoQuality } from 'theoplayer/THEOplayer.chromeless';
+import type { MediaTrack, Quality, TextTrack, VideoQuality } from 'theoplayer/chromeless';
 
 export function isSubtitleTrack(track: TextTrack): boolean {
     return track.kind === 'subtitles' || track.kind === 'captions';


### PR DESCRIPTION
[THEOplayer 6.0 now properly supports JavaScript modules](https://docs.theoplayer.com/changelog.md#officially-announcing-theoplayer-60), allowing modern browsers and bundlers to load a more efficient JavaScript bundle of the player.

This PR updates the Web UI to make full use of this new capability.