### PR TITLE
Fix broken streams

### DIFF
--- a/docs/examples/ads.html
+++ b/docs/examples/ads.html
@@ -33,8 +33,7 @@ permalink: /examples/ads
 <script>
     var ui = document.querySelector('theoplayer-default-ui');
     ui.source = {
-        sources:
-            'https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)',
+        sources: 'https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8',
         ads: [
             {
                 sources: {

--- a/docs/examples/custom-ui.html
+++ b/docs/examples/custom-ui.html
@@ -64,7 +64,7 @@ permalink: /examples/custom-ui
 
 <theoplayer-ui
     configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","license":"{{ site.theoplayer_license }}"}'
-    source='{"sources":"https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)"}'
+    source='{"sources":"https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8"}'
     fluid
 >
     <theoplayer-control-bar slot="top-chrome" class="top-chrome">

--- a/docs/examples/default-ui.html
+++ b/docs/examples/default-ui.html
@@ -13,7 +13,7 @@ permalink: /examples/default-ui
 
 <theoplayer-default-ui
     configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","license":"{{ site.theoplayer_license }}"}'
-    source='{"sources":"https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)"}'
+    source='{"sources":"https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8"}'
     fluid
 >
     <span slot="title">Elephant's Dream</span>

--- a/docs/examples/nitflex.html
+++ b/docs/examples/nitflex.html
@@ -8,7 +8,7 @@ permalink: /examples/nitflex
 <link href="nitflex.css" rel="stylesheet" />
 <theoplayer-ui
     configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","license":"{{ site.theoplayer_license }}"}'
-    source='{"sources":"https://amssamples.streaming.mediaservices.windows.net/7ceb010f-d9a3-467a-915e-5728acced7e3/ElephantsDreamMultiAudio.ism/manifest(format=mpd-time-csf)"}'
+    source='{"sources":"https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8"}'
     fluid
 >
     <theoplayer-control-bar slot="top-chrome" class="top-chrome">


### PR DESCRIPTION
The [Azure Media Services Sample Streams](http://ampdemo.azureedge.net/ams_samplestreams.html) are all offline, presumably because [the service is being retired next year](https://azure.microsoft.com/en-us/updates/retirement-notice-azure-media-services-is-being-retired-on-30-june-2024/).

Replace them with our own streams.