### PR TITLE
Smart TV support 

### DIFF
--- a/docs/examples/custom-ui.html
+++ b/docs/examples/custom-ui.html
@@ -106,10 +106,6 @@ permalink: /examples/custom-ui
 <script>
     var ui = document.querySelector('theoplayer-ui');
     document.querySelector('#mobile-toggle').addEventListener('change', function (ev) {
-        if (ev.target.checked) {
-            ui.setAttribute('mobile', '');
-        } else {
-            ui.removeAttribute('mobile');
-        }
+        ui.setAttribute('device-type', ev.target.checked ? 'mobile' : 'desktop');
     });
 </script>

--- a/docs/examples/default-ui.html
+++ b/docs/examples/default-ui.html
@@ -24,10 +24,6 @@ permalink: /examples/default-ui
 <script>
     var ui = document.querySelector('theoplayer-default-ui');
     document.querySelector('#mobile-toggle').addEventListener('change', function (ev) {
-        if (ev.target.checked) {
-            ui.setAttribute('mobile', '');
-        } else {
-            ui.removeAttribute('mobile');
-        }
+        ui.setAttribute('device-type', ev.target.checked ? 'mobile' : 'desktop');
     });
 </script>

--- a/docs/examples/default-ui.html
+++ b/docs/examples/default-ui.html
@@ -19,11 +19,22 @@ permalink: /examples/default-ui
     <span slot="title">Elephant's Dream</span>
 </theoplayer-default-ui>
 <p>
-    <label style="user-select: none"><input type="checkbox" id="mobile-toggle" /> Mobile</label>
+    <label style="user-select: none">
+        Override device type
+        <select id="device-type-select">
+            <option value=""></option>
+            <option value="desktop">Desktop</option>
+            <option value="mobile">Mobile</option>
+            <option value="tv">TV</option>
+        </select>
+    </label>
 </p>
 <script>
     var ui = document.querySelector('theoplayer-default-ui');
-    document.querySelector('#mobile-toggle').addEventListener('change', function (ev) {
-        ui.setAttribute('device-type', ev.target.checked ? 'mobile' : 'desktop');
+    document.querySelector('#device-type-select').addEventListener('change', function (ev) {
+        var selectedDeviceType = ev.target.value;
+        if (selectedDeviceType) {
+            ui.setAttribute('device-type', selectedDeviceType);
+        }
     });
 </script>

--- a/src/DefaultUI.css
+++ b/src/DefaultUI.css
@@ -161,6 +161,14 @@ theoplayer-ad-skip-button:not([disabled]) {
 }
 
 /*
+ * Tv-hidden elements
+ */
+theoplayer-ui[tv] [tv-hidden],
+theoplayer-ui[tv] theoplayer-control-bar ::slotted([tv-hidden]) {
+    display: none !important;
+}
+
+/*
  * Live-only and live-hidden elements
  */
 :host(:not([stream-type='vod'])) [live-hidden],

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -33,14 +33,14 @@
         </theoplayer-control-bar>
         <theoplayer-control-bar ad-hidden>
             <theoplayer-play-button mobile-hidden></theoplayer-play-button>
-            <theoplayer-mute-button></theoplayer-mute-button>
-            <theoplayer-volume-range mobile-hidden></theoplayer-volume-range>
+            <theoplayer-mute-button tv-hidden></theoplayer-mute-button>
+            <theoplayer-volume-range mobile-hidden tv-hidden></theoplayer-volume-range>
             <theoplayer-live-button live-only ad-hidden></theoplayer-live-button>
             <theoplayer-time-display show-duration remaining-when-live></theoplayer-time-display>
             <span class="theoplayer-spacer" style="pointer-events: auto"></span>
             <theoplayer-language-menu-button menu="language-menu" mobile-hidden ad-hidden></theoplayer-language-menu-button>
-            <theoplayer-airplay-button mobile-hidden ad-hidden></theoplayer-airplay-button>
-            <theoplayer-chromecast-button mobile-hidden ad-hidden></theoplayer-chromecast-button>
+            <theoplayer-airplay-button tv-hidden mobile-hidden ad-hidden></theoplayer-airplay-button>
+            <theoplayer-chromecast-button tv-hidden mobile-hidden ad-hidden></theoplayer-chromecast-button>
             <slot name="bottom-control-bar"></slot>
             <theoplayer-fullscreen-button></theoplayer-fullscreen-button>
         </theoplayer-control-bar>

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -5,7 +5,7 @@ import defaultUiCss from './DefaultUI.css';
 import defaultUiHtml from './DefaultUI.html';
 import { Attribute } from './util/Attribute';
 import { applyExtensions } from './extensions/ExtensionRegistry';
-import { isMobile } from './util/Environment';
+import { isMobile, isTv } from './util/Environment';
 import type { StreamType } from './util/StreamType';
 import type { TimeRange } from './components/TimeRange';
 import { STREAM_TYPE_CHANGE_EVENT } from './events/StreamTypeChangeEvent';
@@ -232,6 +232,8 @@ export class DefaultUI extends HTMLElement {
 
         if (!this.hasAttribute(Attribute.MOBILE) && isMobile()) {
             this.setAttribute(Attribute.MOBILE, '');
+        } else if (!this.hasAttribute(Attribute.TV) && isTv()) {
+            this.setAttribute(Attribute.TV, '');
         }
 
         if (!this._appliedExtensions) {

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -41,8 +41,9 @@ shadyCss.prepareTemplate(template, 'theoplayer-default-ui');
  * @attribute `fluid` - If set, the player automatically adjusts its height to fit the video's aspect ratio.
  * @attribute `muted` - If set, the player starts out as muted. Reflects `ui.player.muted`.
  * @attribute `autoplay` - If set, the player attempts to automatically start playing (if allowed).
- * @attribute `mobile` - Whether to use a mobile-optimized UI layout instead.
- *   Can be used in CSS to show/hide certain desktop-specific or mobile-specific UI controls.
+ * @attribute `device-type` - The device type, either "desktop" or "mobile".
+ *   Can be used in CSS to show/hide certain device-specific UI controls.
+ * @attribute `mobile` - Whether the user is on a mobile device. Equivalent to `device-type == "mobile"`.
  * @attribute `stream-type` - The stream type, either "vod", "live" or "dvr".
  *   Can be used to show/hide certain UI controls specific for livestreams, such as
  *   a {@link LiveButton | `<theoplayer-live-button>`}.
@@ -66,7 +67,7 @@ export class DefaultUI extends HTMLElement {
             Attribute.MUTED,
             Attribute.AUTOPLAY,
             Attribute.FLUID,
-            Attribute.MOBILE,
+            Attribute.DEVICE_TYPE,
             Attribute.STREAM_TYPE,
             Attribute.USER_IDLE_TIMEOUT,
             Attribute.DVR_THRESHOLD,
@@ -260,8 +261,9 @@ export class DefaultUI extends HTMLElement {
             this.autoplay = hasValue;
         } else if (attrName === Attribute.FLUID) {
             toggleAttribute(this._ui, Attribute.FLUID, hasValue);
-        } else if (attrName === Attribute.MOBILE) {
-            toggleAttribute(this._ui, Attribute.MOBILE, hasValue);
+        } else if (attrName === Attribute.DEVICE_TYPE) {
+            toggleAttribute(this, Attribute.MOBILE, newValue === 'mobile');
+            this._ui.setAttribute(Attribute.DEVICE_TYPE, newValue);
         } else if (attrName === Attribute.STREAM_TYPE) {
             this.streamType = newValue;
         } else if (attrName === Attribute.USER_IDLE_TIMEOUT) {

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -41,9 +41,10 @@ shadyCss.prepareTemplate(template, 'theoplayer-default-ui');
  * @attribute `fluid` - If set, the player automatically adjusts its height to fit the video's aspect ratio.
  * @attribute `muted` - If set, the player starts out as muted. Reflects `ui.player.muted`.
  * @attribute `autoplay` - If set, the player attempts to automatically start playing (if allowed).
- * @attribute `device-type` - The device type, either "desktop" or "mobile".
+ * @attribute `device-type` - The device type, either "desktop", "mobile" or "tv".
  *   Can be used in CSS to show/hide certain device-specific UI controls.
  * @attribute `mobile` - Whether the user is on a mobile device. Equivalent to `device-type == "mobile"`.
+ * @attribute `tv` - Whether the user is on a TV device. Equivalent to `device-type == "tv"`.
  * @attribute `stream-type` - The stream type, either "vod", "live" or "dvr".
  *   Can be used to show/hide certain UI controls specific for livestreams, such as
  *   a {@link LiveButton | `<theoplayer-live-button>`}.
@@ -263,6 +264,7 @@ export class DefaultUI extends HTMLElement {
             toggleAttribute(this._ui, Attribute.FLUID, hasValue);
         } else if (attrName === Attribute.DEVICE_TYPE) {
             toggleAttribute(this, Attribute.MOBILE, newValue === 'mobile');
+            toggleAttribute(this, Attribute.TV, newValue === 'tv');
             this._ui.setAttribute(Attribute.DEVICE_TYPE, newValue);
         } else if (attrName === Attribute.STREAM_TYPE) {
             this.streamType = newValue;

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -9,6 +9,7 @@ import { isMobile } from './util/Environment';
 import type { StreamType } from './util/StreamType';
 import type { TimeRange } from './components/TimeRange';
 import { STREAM_TYPE_CHANGE_EVENT } from './events/StreamTypeChangeEvent';
+import { toggleAttribute } from './util/CommonUtils';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${defaultUiCss}</style>${defaultUiHtml}`;
@@ -258,17 +259,9 @@ export class DefaultUI extends HTMLElement {
         } else if (attrName === Attribute.AUTOPLAY) {
             this.autoplay = hasValue;
         } else if (attrName === Attribute.FLUID) {
-            if (hasValue) {
-                this._ui.setAttribute(Attribute.FLUID, newValue);
-            } else {
-                this._ui.removeAttribute(Attribute.FLUID);
-            }
+            toggleAttribute(this._ui, Attribute.FLUID, hasValue);
         } else if (attrName === Attribute.MOBILE) {
-            if (hasValue) {
-                this._ui.setAttribute(Attribute.MOBILE, newValue);
-            } else {
-                this._ui.removeAttribute(Attribute.MOBILE);
-            }
+            toggleAttribute(this._ui, Attribute.MOBILE, hasValue);
         } else if (attrName === Attribute.STREAM_TYPE) {
             this.streamType = newValue;
         } else if (attrName === Attribute.USER_IDLE_TIMEOUT) {
@@ -284,19 +277,11 @@ export class DefaultUI extends HTMLElement {
     private readonly _updateStreamType = () => {
         this.setAttribute(Attribute.STREAM_TYPE, this.streamType);
         // Hide seekbar when stream is live with no DVR
-        if (this.streamType === 'live') {
-            this._timeRange.setAttribute(Attribute.HIDDEN, '');
-        } else {
-            this._timeRange.removeAttribute(Attribute.HIDDEN);
-        }
+        toggleAttribute(this._timeRange, Attribute.HIDDEN, this.streamType === 'live');
     };
 
     private readonly _onTitleSlotChange = () => {
-        if (this._titleSlot.assignedNodes().length > 0) {
-            this.setAttribute(Attribute.HAS_TITLE, '');
-        } else {
-            this.removeAttribute(Attribute.HAS_TITLE);
-        }
+        toggleAttribute(this, Attribute.HAS_TITLE, this._titleSlot.assignedNodes().length > 0);
     };
 }
 

--- a/src/UIContainer.css
+++ b/src/UIContainer.css
@@ -107,7 +107,7 @@
     pointer-events: none;
 }
 
-:host(:not([mobile])) [part~='menu-layer'] {
+:host(:not([mobile]):not([tv])) [part~='menu-layer'] {
     top: var(--theoplayer-menu-offset-top, 0);
     bottom: var(--theoplayer-menu-offset-bottom, 0);
     padding: var(--theoplayer-menu-layer-padding, 10px);
@@ -153,7 +153,16 @@
     @mixin menu-fill-styles;
 }
 
+:host([tv]) [part~='menu-layer'] {
+    left: auto;
+}
+
+:host([tv]) [part='menu'] {
+    @mixin menu-fill-styles;
+}
+
 :host(:not([menu-opened])) [part~='menu-layer'],
+:host([menu-opened][tv]) [part~='vertical-layer'],
 :host([menu-opened][mobile]) [part~='vertical-layer'] {
     display: none !important;
 }

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -921,10 +921,8 @@ export class UIContainer extends HTMLElement {
                 return;
             }
             if (event.keyCode === KeyCode.ENTER) {
-                if (this._player !== undefined) {
-                    if (isHTMLElement(focusedChild)) {
-                        focusedChild.click();
-                    }
+                if (this._player !== undefined && focusedChild !== null) {
+                    focusedChild.click();
                 }
             } else if (isArrowKey(event.keyCode) && navigateByArrowKey(this, getFocusableChildren(this), event.keyCode)) {
                 event.preventDefault();

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -6,6 +6,7 @@ import {
     arrayFind,
     arrayRemove,
     containsComposedNode,
+    getActiveElement,
     getFocusableChildren,
     isElement,
     isHTMLElement,
@@ -33,7 +34,7 @@ import './components/MenuGroup';
 import { MENU_CHANGE_EVENT } from './events/MenuChangeEvent';
 import type { DeviceType } from './util/DeviceType';
 import { isArrowKey, KeyCode } from './util/KeyCode';
-import { navigateByArrowKey } from './util/KeyboardNavigation';
+import { getFocusedChild, navigateByArrowKey } from './util/KeyboardNavigation';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${elementCss}</style>${elementHtml}`;
@@ -914,7 +915,19 @@ export class UIContainer extends HTMLElement {
 
     private readonly _onKeyDown = (event: KeyboardEvent): void => {
         if (this.deviceType === 'tv') {
-            if (isArrowKey(event.keyCode) && navigateByArrowKey(this, getFocusableChildren(this), event.keyCode)) {
+            if (this.isUserIdle_()) {
+                // First button press should only make the UI visible
+                getFocusedChild(getFocusableChildren(this));
+                return;
+            }
+            if (event.keyCode === KeyCode.ENTER) {
+                if (this._player !== undefined) {
+                    const focusedChild = getActiveElement();
+                    if (isHTMLElement(focusedChild)) {
+                        focusedChild.click();
+                    }
+                }
+            } else if (isArrowKey(event.keyCode) && navigateByArrowKey(this, getFocusableChildren(this), event.keyCode)) {
                 event.preventDefault();
                 event.stopPropagation();
             } else if (event.keyCode === KeyCode.BACK) {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -33,8 +33,8 @@ import type { MenuGroup } from './components';
 import './components/MenuGroup';
 import { MENU_CHANGE_EVENT } from './events/MenuChangeEvent';
 import type { DeviceType } from './util/DeviceType';
-import { isArrowKey, KeyCode } from './util/KeyCode';
 import { getFocusedChild, navigateByArrowKey } from './util/KeyboardNavigation';
+import { isArrowKey, isBackKey, KeyCode } from './util/KeyCode';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${elementCss}</style>${elementHtml}`;
@@ -930,7 +930,7 @@ export class UIContainer extends HTMLElement {
             } else if (isArrowKey(event.keyCode) && navigateByArrowKey(this, getFocusableChildren(this), event.keyCode)) {
                 event.preventDefault();
                 event.stopPropagation();
-            } else if (event.keyCode === KeyCode.BACK) {
+            } else if (isBackKey(event.keyCode)) {
                 this.setUserIdle_();
             }
         }
@@ -938,7 +938,7 @@ export class UIContainer extends HTMLElement {
 
     private readonly _onKeyUp = (event: KeyboardEvent): void => {
         // Show the controls while navigating with the keyboard.
-        if (event.keyCode !== KeyCode.BACK) {
+        if (!isBackKey(event.keyCode)) {
             this.scheduleUserIdle_();
         }
     };

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -40,6 +40,7 @@ template.innerHTML = `<style>${elementCss}</style>${elementHtml}`;
 shadyCss.prepareTemplate(template, 'theoplayer-ui');
 
 const DEFAULT_USER_IDLE_TIMEOUT = 2;
+const DEFAULT_TV_USER_IDLE_TIMEOUT = 5;
 const DEFAULT_DVR_THRESHOLD = 60;
 
 /**
@@ -310,7 +311,8 @@ export class UIContainer extends HTMLElement {
      * and when the user is considered to be "idle".
      */
     get userIdleTimeout(): number {
-        return Number(this.getAttribute(Attribute.USER_IDLE_TIMEOUT) ?? DEFAULT_USER_IDLE_TIMEOUT);
+        const defaultTimeout = this.deviceType === 'tv' ? DEFAULT_TV_USER_IDLE_TIMEOUT : DEFAULT_USER_IDLE_TIMEOUT;
+        return Number(this.getAttribute(Attribute.USER_IDLE_TIMEOUT) ?? defaultTimeout);
     }
 
     set userIdleTimeout(value: number) {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -385,7 +385,7 @@ export class UIContainer extends HTMLElement {
         }
 
         this.setUserIdle_();
-        this.addEventListener('keydown', this._onKeyDown);
+        window.addEventListener('keydown', this._onKeyDown);
         this.addEventListener('keyup', this._onKeyUp);
         this.addEventListener('pointerup', this._onPointerUp);
         this.addEventListener('pointermove', this._onPointerMove);
@@ -450,7 +450,7 @@ export class UIContainer extends HTMLElement {
             document.removeEventListener(fullscreenAPI.fullscreenerror_, this._onFullscreenChange);
         }
 
-        this.removeEventListener('keydown', this._onKeyDown);
+        window.removeEventListener('keydown', this._onKeyDown);
         this.removeEventListener('keyup', this._onKeyUp);
         this.removeEventListener('pointerup', this._onPointerUp);
         this.removeEventListener('click', this._onClickAfterPointerUp, true);

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -2,7 +2,16 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { ChromelessPlayer, type MediaTrack, type PlayerConfiguration, type SourceDescription, type VideoQuality } from 'theoplayer/chromeless';
 import elementCss from './UIContainer.css';
 import elementHtml from './UIContainer.html';
-import { arrayFind, arrayRemove, containsComposedNode, isElement, isHTMLElement, noOp, toggleAttribute } from './util/CommonUtils';
+import {
+    arrayFind,
+    arrayRemove,
+    containsComposedNode,
+    getFocusableChildren,
+    isElement,
+    isHTMLElement,
+    noOp,
+    toggleAttribute
+} from './util/CommonUtils';
 import { forEachStateReceiverElement, type StateReceiverElement, StateReceiverProps } from './components/StateReceiverMixin';
 import { TOGGLE_MENU_EVENT, type ToggleMenuEvent } from './events/ToggleMenuEvent';
 import { CLOSE_MENU_EVENT } from './events/CloseMenuEvent';
@@ -376,6 +385,7 @@ export class UIContainer extends HTMLElement {
         }
 
         this.setUserIdle_();
+        this.addEventListener('keydown', this._onKeyDown);
         this.addEventListener('keyup', this._onKeyUp);
         this.addEventListener('pointerup', this._onPointerUp);
         this.addEventListener('pointermove', this._onPointerMove);
@@ -440,6 +450,7 @@ export class UIContainer extends HTMLElement {
             document.removeEventListener(fullscreenAPI.fullscreenerror_, this._onFullscreenChange);
         }
 
+        this.removeEventListener('keydown', this._onKeyDown);
         this.removeEventListener('keyup', this._onKeyUp);
         this.removeEventListener('pointerup', this._onPointerUp);
         this.removeEventListener('click', this._onClickAfterPointerUp, true);
@@ -899,13 +910,16 @@ export class UIContainer extends HTMLElement {
         return node === this || this._playerEl.contains(node);
     }
 
-    private readonly _onKeyUp = (event: KeyboardEvent): void => {
-        // Show the controls while navigating with the keyboard.
-        this.scheduleUserIdle_();
-        if (this.deviceType === 'tv' && isArrowKey(event.keyCode) && navigateByArrowKey(this, event.keyCode)) {
+    private readonly _onKeyDown = (event: KeyboardEvent): void => {
+        if (this.deviceType === 'tv' && isArrowKey(event.keyCode) && navigateByArrowKey(this, getFocusableChildren(this), event.keyCode)) {
             event.preventDefault();
             event.stopPropagation();
         }
+    };
+
+    private readonly _onKeyUp = (): void => {
+        // Show the controls while navigating with the keyboard.
+        this.scheduleUserIdle_();
     };
 
     private readonly _onPointerUp = (event: PointerEvent): void => {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -915,14 +915,13 @@ export class UIContainer extends HTMLElement {
 
     private readonly _onKeyDown = (event: KeyboardEvent): void => {
         if (this.deviceType === 'tv') {
+            const focusedChild = getFocusedChild(getFocusableChildren(this));
             if (this.isUserIdle_()) {
                 // First button press should only make the UI visible
-                getFocusedChild(getFocusableChildren(this));
                 return;
             }
             if (event.keyCode === KeyCode.ENTER) {
                 if (this._player !== undefined) {
-                    const focusedChild = getActiveElement();
                     if (isHTMLElement(focusedChild)) {
                         focusedChild.click();
                     }

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -10,7 +10,7 @@ import { ENTER_FULLSCREEN_EVENT, type EnterFullscreenEvent } from './events/Ente
 import { EXIT_FULLSCREEN_EVENT, type ExitFullscreenEvent } from './events/ExitFullscreenEvent';
 import { fullscreenAPI } from './util/FullscreenUtils';
 import { Attribute } from './util/Attribute';
-import { isMobile } from './util/Environment';
+import { isMobile, isTv } from './util/Environment';
 import { Rectangle } from './util/GeometryUtils';
 import './components/GestureReceiver';
 import { PREVIEW_TIME_CHANGE_EVENT, type PreviewTimeChangeEvent } from './events/PreviewTimeChangeEvent';
@@ -58,9 +58,10 @@ const DEFAULT_DVR_THRESHOLD = 60;
  * @attribute `fluid` - If set, the player automatically adjusts its height to fit the video's aspect ratio.
  * @attribute `muted` - If set, the player starts out as muted. Reflects `ui.player.muted`.
  * @attribute `autoplay` - If set, the player attempts to automatically start playing (if allowed).
- * @attribute `device-type` - The device type, either "desktop" or "mobile".
+ * @attribute `device-type` - The device type, either "desktop", "mobile" or "tv".
  *   Can be used in CSS to show/hide certain device-specific UI controls.
  * @attribute `mobile` - Whether the user is on a mobile device. Equivalent to `device-type == "mobile"`.
+ * @attribute `tv` - Whether the user is on a TV device. Equivalent to `device-type == "tv"`.
  * @attribute `stream-type` - The stream type, either "vod", "live" or "dvr".
  *   Can be used to show/hide certain UI controls specific for livestreams, such as
  *   a {@link LiveButton | `<theoplayer-live-button>`}.
@@ -337,7 +338,7 @@ export class UIContainer extends HTMLElement {
         shadyCss.styleElement(this);
 
         if (!this.hasAttribute(Attribute.DEVICE_TYPE)) {
-            const deviceType: DeviceType = isMobile() ? 'mobile' : 'desktop';
+            const deviceType: DeviceType = isMobile() ? 'mobile' : isTv() ? 'tv' : 'desktop';
             this.setAttribute(Attribute.DEVICE_TYPE, deviceType);
         }
         if (!this.hasAttribute(Attribute.PAUSED)) {
@@ -467,6 +468,7 @@ export class UIContainer extends HTMLElement {
             }
         } else if (attrName === Attribute.DEVICE_TYPE) {
             toggleAttribute(this, Attribute.MOBILE, newValue === 'mobile');
+            toggleAttribute(this, Attribute.TV, newValue === 'tv');
         } else if (attrName === Attribute.STREAM_TYPE) {
             for (const receiver of this._stateReceivers) {
                 if (receiver[StateReceiverProps].indexOf('streamType') >= 0) {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -920,6 +920,11 @@ export class UIContainer extends HTMLElement {
 
     private readonly _onKeyDown = (event: KeyboardEvent): void => {
         if (this.deviceType === 'tv') {
+            if (isBackKey(event.keyCode)) {
+                this.setUserIdle_();
+                return;
+            }
+
             const focusedChild = getFocusedChild(getFocusableChildren(this));
             if (this.isUserIdle_()) {
                 // First button press should only make the UI visible
@@ -932,8 +937,6 @@ export class UIContainer extends HTMLElement {
             } else if (isArrowKey(event.keyCode) && navigateByArrowKey(this, getFocusableChildren(this), event.keyCode)) {
                 event.preventDefault();
                 event.stopPropagation();
-            } else if (isBackKey(event.keyCode)) {
-                this.setUserIdle_();
             }
         }
     };

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -32,7 +32,7 @@ import type { MenuGroup } from './components';
 import './components/MenuGroup';
 import { MENU_CHANGE_EVENT } from './events/MenuChangeEvent';
 import type { DeviceType } from './util/DeviceType';
-import { isArrowKey } from './util/KeyCode';
+import { isArrowKey, KeyCode } from './util/KeyCode';
 import { navigateByArrowKey } from './util/KeyboardNavigation';
 
 const template = document.createElement('template');
@@ -911,15 +911,21 @@ export class UIContainer extends HTMLElement {
     }
 
     private readonly _onKeyDown = (event: KeyboardEvent): void => {
-        if (this.deviceType === 'tv' && isArrowKey(event.keyCode) && navigateByArrowKey(this, getFocusableChildren(this), event.keyCode)) {
-            event.preventDefault();
-            event.stopPropagation();
+        if (this.deviceType === 'tv') {
+            if (isArrowKey(event.keyCode) && navigateByArrowKey(this, getFocusableChildren(this), event.keyCode)) {
+                event.preventDefault();
+                event.stopPropagation();
+            } else if (event.keyCode === KeyCode.BACK) {
+                this.setUserIdle_();
+            }
         }
     };
 
-    private readonly _onKeyUp = (): void => {
+    private readonly _onKeyUp = (event: KeyboardEvent): void => {
         // Show the controls while navigating with the keyboard.
-        this.scheduleUserIdle_();
+        if (event.keyCode !== KeyCode.BACK) {
+            this.scheduleUserIdle_();
+        }
     };
 
     private readonly _onPointerUp = (event: PointerEvent): void => {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { ChromelessPlayer, type MediaTrack, type PlayerConfiguration, type SourceDescription, type VideoQuality } from 'theoplayer/chromeless';
 import elementCss from './UIContainer.css';
 import elementHtml from './UIContainer.html';
-import { arrayFind, arrayRemove, containsComposedNode, isElement, isHTMLElement, noOp } from './util/CommonUtils';
+import { arrayFind, arrayRemove, containsComposedNode, isElement, isHTMLElement, noOp, toggleAttribute } from './util/CommonUtils';
 import { forEachStateReceiverElement, type StateReceiverElement, StateReceiverProps } from './components/StateReceiverMixin';
 import { TOGGLE_MENU_EVENT, type ToggleMenuEvent } from './events/ToggleMenuEvent';
 import { CLOSE_MENU_EVENT } from './events/CloseMenuEvent';
@@ -249,11 +249,7 @@ export class UIContainer extends HTMLElement {
     }
 
     set muted(value: boolean) {
-        if (value) {
-            this.setAttribute(Attribute.MUTED, '');
-        } else {
-            this.removeAttribute(Attribute.MUTED);
-        }
+        toggleAttribute(this, Attribute.MUTED, value);
     }
 
     /**
@@ -264,11 +260,7 @@ export class UIContainer extends HTMLElement {
     }
 
     set autoplay(value: boolean) {
-        if (value) {
-            this.setAttribute(Attribute.AUTOPLAY, '');
-        } else {
-            this.removeAttribute(Attribute.AUTOPLAY);
-        }
+        toggleAttribute(this, Attribute.AUTOPLAY, value);
     }
 
     /**
@@ -700,11 +692,7 @@ export class UIContainer extends HTMLElement {
         if (!isFullscreen && this._player !== undefined && this._player.presentation.currentMode === 'fullscreen') {
             isFullscreen = true;
         }
-        if (isFullscreen) {
-            this.setAttribute(Attribute.FULLSCREEN, '');
-        } else {
-            this.removeAttribute(Attribute.FULLSCREEN);
-        }
+        toggleAttribute(this, Attribute.FULLSCREEN, isFullscreen);
     };
 
     private readonly _updateAspectRatio = (): void => {
@@ -727,11 +715,7 @@ export class UIContainer extends HTMLElement {
 
     private readonly _updateError = (): void => {
         const error = this._player?.errorObject;
-        if (error) {
-            this.setAttribute(Attribute.HAS_ERROR, '');
-        } else {
-            this.removeAttribute(Attribute.HAS_ERROR);
-        }
+        toggleAttribute(this, Attribute.HAS_ERROR, error !== undefined);
         for (const receiver of this._stateReceivers) {
             if (receiver[StateReceiverProps].indexOf('error') >= 0) {
                 receiver.error = error;
@@ -752,21 +736,13 @@ export class UIContainer extends HTMLElement {
 
     private readonly _updatePausedAndEnded = (): void => {
         const paused = this._player ? this._player.paused : true;
-        if (paused) {
-            this.setAttribute(Attribute.PAUSED, '');
-        } else {
-            this.removeAttribute(Attribute.PAUSED);
-        }
+        toggleAttribute(this, Attribute.PAUSED, paused);
         this._updateEnded();
     };
 
     private readonly _updateEnded = (): void => {
         const ended = this._player ? this._player.ended : false;
-        if (ended) {
-            this.setAttribute(Attribute.ENDED, '');
-        } else {
-            this.removeAttribute(Attribute.ENDED);
-        }
+        toggleAttribute(this, Attribute.ENDED, ended);
     };
 
     private readonly _updateStreamType = (): void => {
@@ -846,29 +822,18 @@ export class UIContainer extends HTMLElement {
 
     private readonly _updateCasting = (): void => {
         const casting = this._player?.cast?.casting ?? false;
-        if (casting) {
-            this.setAttribute(Attribute.CASTING, '');
-        } else {
-            this.removeAttribute(Attribute.CASTING);
-        }
+        toggleAttribute(this, Attribute.CASTING, casting);
     };
 
     private readonly _updatePlayingAd = (): void => {
         const playingAd = this._player?.ads?.playing ?? false;
-        if (playingAd) {
-            this.setAttribute(Attribute.PLAYING_AD, '');
-        } else {
-            this.removeAttribute(Attribute.PLAYING_AD);
-        }
+        toggleAttribute(this, Attribute.PLAYING_AD, playingAd);
     };
 
     private readonly _onSourceChange = (): void => {
         this.closeMenu_();
-        if (this._player !== undefined && !this._player.paused) {
-            this.setAttribute(Attribute.HAS_FIRST_PLAY, '');
-        } else {
-            this.removeAttribute(Attribute.HAS_FIRST_PLAY);
-        }
+        const isPlaying = this._player !== undefined && !this._player.paused;
+        toggleAttribute(this, Attribute.HAS_FIRST_PLAY, isPlaying);
     };
 
     private isUserIdle_(): boolean {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -308,6 +308,13 @@ export class UIContainer extends HTMLElement {
     }
 
     /**
+     * The device type, either "desktop", "mobile" or "tv".
+     */
+    get deviceType(): DeviceType {
+        return (this.getAttribute(Attribute.DEVICE_TYPE) as DeviceType) || 'desktop';
+    }
+
+    /**
      * The stream type, either "vod", "live" or "dvr".
      *
      * If you know in advance that the source will be a livestream, you can set this property to avoid a screen flicker
@@ -469,6 +476,11 @@ export class UIContainer extends HTMLElement {
         } else if (attrName === Attribute.DEVICE_TYPE) {
             toggleAttribute(this, Attribute.MOBILE, newValue === 'mobile');
             toggleAttribute(this, Attribute.TV, newValue === 'tv');
+            for (const receiver of this._stateReceivers) {
+                if (receiver[StateReceiverProps].indexOf('deviceType') >= 0) {
+                    receiver.deviceType = newValue;
+                }
+            }
         } else if (attrName === Attribute.STREAM_TYPE) {
             for (const receiver of this._stateReceivers) {
                 if (receiver[StateReceiverProps].indexOf('streamType') >= 0) {
@@ -540,6 +552,9 @@ export class UIContainer extends HTMLElement {
         }
         if (receiverProps.indexOf('fullscreen') >= 0) {
             receiver.fullscreen = this.fullscreen;
+        }
+        if (receiverProps.indexOf('deviceType') >= 0) {
+            receiver.deviceType = this.deviceType;
         }
         if (receiverProps.indexOf('streamType') >= 0) {
             receiver.streamType = this.streamType;

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -22,6 +22,7 @@ import { getTargetQualities } from './util/TrackUtils';
 import type { MenuGroup } from './components';
 import './components/MenuGroup';
 import { MENU_CHANGE_EVENT } from './events/MenuChangeEvent';
+import type { DeviceType } from './util/DeviceType';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${elementCss}</style>${elementHtml}`;
@@ -57,8 +58,9 @@ const DEFAULT_DVR_THRESHOLD = 60;
  * @attribute `fluid` - If set, the player automatically adjusts its height to fit the video's aspect ratio.
  * @attribute `muted` - If set, the player starts out as muted. Reflects `ui.player.muted`.
  * @attribute `autoplay` - If set, the player attempts to automatically start playing (if allowed).
- * @attribute `mobile` - Whether to use a mobile-optimized UI layout instead.
- *   Can be used in CSS to show/hide certain desktop-specific or mobile-specific UI controls.
+ * @attribute `device-type` - The device type, either "desktop" or "mobile".
+ *   Can be used in CSS to show/hide certain device-specific UI controls.
+ * @attribute `mobile` - Whether the user is on a mobile device. Equivalent to `device-type == "mobile"`.
  * @attribute `stream-type` - The stream type, either "vod", "live" or "dvr".
  *   Can be used to show/hide certain UI controls specific for livestreams, such as
  *   a {@link LiveButton | `<theoplayer-live-button>`}.
@@ -102,7 +104,7 @@ export class UIContainer extends HTMLElement {
             Attribute.AUTOPLAY,
             Attribute.FULLSCREEN,
             Attribute.FLUID,
-            Attribute.MOBILE,
+            Attribute.DEVICE_TYPE,
             Attribute.PAUSED,
             Attribute.ENDED,
             Attribute.CASTING,
@@ -334,8 +336,9 @@ export class UIContainer extends HTMLElement {
     connectedCallback(): void {
         shadyCss.styleElement(this);
 
-        if (!this.hasAttribute(Attribute.MOBILE) && isMobile()) {
-            this.setAttribute(Attribute.MOBILE, '');
+        if (!this.hasAttribute(Attribute.DEVICE_TYPE)) {
+            const deviceType: DeviceType = isMobile() ? 'mobile' : 'desktop';
+            this.setAttribute(Attribute.DEVICE_TYPE, deviceType);
         }
         if (!this.hasAttribute(Attribute.PAUSED)) {
             this.setAttribute(Attribute.PAUSED, '');
@@ -462,6 +465,8 @@ export class UIContainer extends HTMLElement {
                     receiver.fullscreen = hasValue;
                 }
             }
+        } else if (attrName === Attribute.DEVICE_TYPE) {
+            toggleAttribute(this, Attribute.MOBILE, newValue === 'mobile');
         } else if (attrName === Attribute.STREAM_TYPE) {
             for (const receiver of this._stateReceivers) {
                 if (receiver[StateReceiverProps].indexOf('streamType') >= 0) {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -23,6 +23,8 @@ import type { MenuGroup } from './components';
 import './components/MenuGroup';
 import { MENU_CHANGE_EVENT } from './events/MenuChangeEvent';
 import type { DeviceType } from './util/DeviceType';
+import { isArrowKey } from './util/KeyCode';
+import { navigateByArrowKey } from './util/KeyboardNavigation';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${elementCss}</style>${elementHtml}`;
@@ -897,9 +899,13 @@ export class UIContainer extends HTMLElement {
         return node === this || this._playerEl.contains(node);
     }
 
-    private readonly _onKeyUp = (): void => {
+    private readonly _onKeyUp = (event: KeyboardEvent): void => {
         // Show the controls while navigating with the keyboard.
         this.scheduleUserIdle_();
+        if (this.deviceType === 'tv' && isArrowKey(event.keyCode) && navigateByArrowKey(this, event.keyCode)) {
+            event.preventDefault();
+            event.stopPropagation();
+        }
     };
 
     private readonly _onPointerUp = (event: PointerEvent): void => {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -891,8 +891,13 @@ export class UIContainer extends HTMLElement {
         if (this.userIdleTimeout < 0) {
             return;
         }
-
         this.setAttribute(Attribute.USER_IDLE, '');
+
+        // Blur active element so that first key press on TV doesn't result in an action.
+        const focusedChild = getFocusedChild(getFocusableChildren(this));
+        if (this.deviceType === 'tv' && focusedChild !== null && this.isUserIdle_()) {
+            focusedChild.blur();
+        }
     };
 
     private readonly scheduleUserIdle_ = (): void => {

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -2,6 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import buttonCss from './Button.css';
 import { KeyCode } from '../util/KeyCode';
 import { Attribute } from '../util/Attribute';
+import { toggleAttribute } from '../util/CommonUtils';
 
 export interface ButtonOptions {
     template: HTMLTemplateElement;
@@ -87,11 +88,7 @@ export class Button extends HTMLElement {
     }
 
     set disabled(disabled: boolean) {
-        if (disabled) {
-            this.setAttribute(Attribute.DISABLED, '');
-        } else {
-            this.removeAttribute(Attribute.DISABLED);
-        }
+        toggleAttribute(this, Attribute.DISABLED, disabled);
     }
 
     attributeChangedCallback(attrName: string, oldValue: any, newValue: any) {

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -69,12 +69,10 @@ export class Button extends HTMLElement {
             this.setAttribute(Attribute.ARIA_LIVE, 'polite');
         }
 
-        this.addEventListener('keydown', this._onKeyDown);
         this.addEventListener('click', this._onClick);
     }
 
     disconnectedCallback(): void {
-        this.removeEventListener('keydown', this._onKeyDown);
         this.removeEventListener('click', this._onClick);
     }
 
@@ -110,23 +108,6 @@ export class Button extends HTMLElement {
             shadyCss.styleSubtree(this);
         }
     }
-
-    private readonly _onKeyDown = (event: KeyboardEvent) => {
-        // Don't handle modifier shortcuts typically used by assistive technology.
-        if (event.altKey) return;
-
-        switch (event.keyCode) {
-            case KeyCode.SPACE:
-            case KeyCode.ENTER:
-                event.preventDefault();
-                event.stopPropagation();
-                this._onClick();
-                break;
-            // Any other key press is ignored and passed back to the browser.
-            default:
-                return;
-        }
-    };
 
     private readonly _onClick = () => {
         if (this.disabled) {

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -119,6 +119,7 @@ export class Button extends HTMLElement {
             case KeyCode.SPACE:
             case KeyCode.ENTER:
                 event.preventDefault();
+                event.stopPropagation();
                 this._onClick();
                 break;
             // Any other key press is ignored and passed back to the browser.

--- a/src/components/ChromecastButton.ts
+++ b/src/components/ChromecastButton.ts
@@ -30,7 +30,7 @@ export class ChromecastButton extends StateReceiverMixin(CastButton, ['player'])
         const mask = this.shadowRoot!.querySelector<SVGClipPathElement>(`svg clipPath#${maskId}`)!;
         const rings = this.shadowRoot!.querySelector<SVGGElement>(`svg .theoplayer-chromecast-rings`)!;
         const uniqueMaskId = `${maskId}-${id}`;
-        mask.setAttribute('id', uniqueMaskId);
+        mask?.setAttribute('id', uniqueMaskId);
         rings.setAttribute('clip-path', uniqueMaskId);
 
         this._upgradeProperty('player');

--- a/src/components/ErrorDisplay.ts
+++ b/src/components/ErrorDisplay.ts
@@ -3,7 +3,7 @@ import errorDisplayCss from './ErrorDisplay.css';
 import errorIcon from '../icons/error.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import type { THEOplayerError } from 'theoplayer/chromeless';
-import { setTextContent } from '../util/CommonUtils';
+import { setTextContent, toggleAttribute } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 
 const template = document.createElement('template');
@@ -72,11 +72,7 @@ export class ErrorDisplay extends StateReceiverMixin(HTMLElement, ['error', 'ful
     }
 
     set fullscreen(fullscreen: boolean) {
-        if (fullscreen) {
-            this.setAttribute(Attribute.FULLSCREEN, '');
-        } else {
-            this.removeAttribute(Attribute.FULLSCREEN);
-        }
+        toggleAttribute(this, Attribute.FULLSCREEN, fullscreen);
     }
 
     attributeChangedCallback(attrName: string, oldValue: any, newValue: any) {

--- a/src/components/FullscreenButton.ts
+++ b/src/components/FullscreenButton.ts
@@ -8,6 +8,7 @@ import { createCustomEvent } from '../util/EventUtils';
 import { ENTER_FULLSCREEN_EVENT, type EnterFullscreenEvent } from '../events/EnterFullscreenEvent';
 import { EXIT_FULLSCREEN_EVENT, type ExitFullscreenEvent } from '../events/ExitFullscreenEvent';
 import { Attribute } from '../util/Attribute';
+import { toggleAttribute } from '../util/CommonUtils';
 
 const template = document.createElement('template');
 template.innerHTML = buttonTemplate(
@@ -42,11 +43,7 @@ export class FullscreenButton extends StateReceiverMixin(Button, ['fullscreen'])
     }
 
     set fullscreen(fullscreen: boolean) {
-        if (fullscreen) {
-            this.setAttribute(Attribute.FULLSCREEN, '');
-        } else {
-            this.removeAttribute(Attribute.FULLSCREEN);
-        }
+        toggleAttribute(this, Attribute.FULLSCREEN, fullscreen);
     }
 
     protected override handleClick(): void {

--- a/src/components/LanguageMenu.ts
+++ b/src/components/LanguageMenu.ts
@@ -8,6 +8,7 @@ import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 import './TrackRadioGroup';
 import './TextTrackStyleMenu';
+import { toggleAttribute } from '../util/CommonUtils';
 
 const template = document.createElement('template');
 template.innerHTML = menuGroupTemplate(languageMenuHtml, languageMenuCss);
@@ -56,21 +57,13 @@ export class LanguageMenu extends StateReceiverMixin(MenuGroup, ['player']) {
     private readonly _updateAudioTracks = (): void => {
         const newAudioTracks: readonly MediaTrack[] = this._player?.audioTracks ?? [];
         // Hide audio track selection if there's only one track.
-        if (newAudioTracks.length < 2) {
-            this.removeAttribute(Attribute.HAS_AUDIO);
-        } else {
-            this.setAttribute(Attribute.HAS_AUDIO, '');
-        }
+        toggleAttribute(this, Attribute.HAS_AUDIO, newAudioTracks.length > 1);
     };
 
     private readonly _updateTextTracks = (): void => {
         const newSubtitleTracks: readonly TextTrack[] = this._player?.textTracks.filter(isSubtitleTrack) ?? [];
         // Hide subtitle track selection if there are no tracks. If there's one, we still show an "off" option.
-        if (newSubtitleTracks.length === 0) {
-            this.removeAttribute(Attribute.HAS_SUBTITLES);
-        } else {
-            this.setAttribute(Attribute.HAS_SUBTITLES, '');
-        }
+        toggleAttribute(this, Attribute.HAS_SUBTITLES, newSubtitleTracks.length > 0);
     };
 
     override attributeChangedCallback(attrName: string, oldValue: any, newValue: any) {

--- a/src/components/LanguageMenuButton.ts
+++ b/src/components/LanguageMenuButton.ts
@@ -6,6 +6,7 @@ import { StateReceiverMixin } from './StateReceiverMixin';
 import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
+import { toggleAttribute } from '../util/CommonUtils';
 
 const template = document.createElement('template');
 template.innerHTML = buttonTemplate(`<span part="icon"><slot>${languageIcon}</slot></span>`);
@@ -59,11 +60,7 @@ export class LanguageMenuButton extends StateReceiverMixin(MenuButton, ['player'
 
     private readonly _updateTracks = (): void => {
         const hasTracks = this._player !== undefined && (this._player.audioTracks.length >= 2 || this._player.textTracks.some(isSubtitleTrack));
-        if (hasTracks) {
-            this.removeAttribute('hidden');
-        } else {
-            this.setAttribute('hidden', '');
-        }
+        toggleAttribute(this, Attribute.HIDDEN, !hasTracks);
     };
 }
 

--- a/src/components/LinkButton.ts
+++ b/src/components/LinkButton.ts
@@ -4,6 +4,7 @@ import { Attribute } from '../util/Attribute';
 import type { ButtonOptions } from './Button';
 import { Button, buttonTemplate } from './Button';
 import { KeyCode } from '../util/KeyCode';
+import { toggleAttribute } from '../util/CommonUtils';
 
 export function linkButtonTemplate(button: string, extraCss: string = ''): string {
     return buttonTemplate(`<a>${button}</a>`, `${linkButtonCss}\n${extraCss}`);
@@ -79,11 +80,7 @@ export class LinkButton extends HTMLElement {
     }
 
     set disabled(disabled: boolean) {
-        if (disabled) {
-            this.setAttribute(Attribute.DISABLED, '');
-        } else {
-            this.removeAttribute(Attribute.DISABLED);
-        }
+        toggleAttribute(this, Attribute.DISABLED, disabled);
     }
 
     protected setLink(href: string, target: string): void {

--- a/src/components/LiveButton.ts
+++ b/src/components/LiveButton.ts
@@ -6,6 +6,7 @@ import liveIcon from '../icons/live.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { Attribute } from '../util/Attribute';
 import type { StreamType } from '../util/StreamType';
+import { toggleAttribute } from '../util/CommonUtils';
 
 const template = document.createElement('template');
 template.innerHTML = buttonTemplate(
@@ -59,11 +60,7 @@ export class LiveButton extends StateReceiverMixin(Button, ['player', 'streamTyp
     }
 
     set paused(paused: boolean) {
-        if (paused) {
-            this.setAttribute(Attribute.PAUSED, '');
-        } else {
-            this.removeAttribute(Attribute.PAUSED);
-        }
+        toggleAttribute(this, Attribute.PAUSED, paused);
     }
 
     get streamType(): StreamType {
@@ -88,11 +85,7 @@ export class LiveButton extends StateReceiverMixin(Button, ['player', 'streamTyp
     }
 
     set live(live: boolean) {
-        if (live) {
-            this.setAttribute(Attribute.LIVE, '');
-        } else {
-            this.removeAttribute(Attribute.LIVE);
-        }
+        toggleAttribute(this, Attribute.LIVE, live);
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/LiveButton.ts
+++ b/src/components/LiveButton.ts
@@ -114,7 +114,10 @@ export class LiveButton extends StateReceiverMixin(Button, ['player', 'streamTyp
     };
 
     private readonly _updateLive = () => {
-        this.live = this._player !== undefined ? isLive(this._player, this.liveThreshold) : false;
+        const live = this._player !== undefined ? isLive(this._player, this.liveThreshold) : false;
+        if (this.live !== live) {
+            this.live = live;
+        }
     };
 
     protected override handleClick() {

--- a/src/components/LoadingIndicator.ts
+++ b/src/components/LoadingIndicator.ts
@@ -4,6 +4,7 @@ import loadingIndicatorHtml from './LoadingIndicator.html';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { Attribute } from '../util/Attribute';
+import { toggleAttribute } from '../util/CommonUtils';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${loadingIndicatorCss}</style>${loadingIndicatorHtml}`;
@@ -66,11 +67,7 @@ export class LoadingIndicator extends StateReceiverMixin(HTMLElement, ['player']
 
     private readonly _updateFromPlayer = () => {
         const loading = this._player !== undefined && !this._player.paused && (this._player.seeking || this._player.readyState < 3);
-        if (loading) {
-            this.setAttribute(Attribute.LOADING, '');
-        } else {
-            this.removeAttribute(Attribute.LOADING);
-        }
+        toggleAttribute(this, Attribute.LOADING, loading);
     };
 
     attributeChangedCallback(attrName: string, oldValue: any, newValue: any) {

--- a/src/components/Menu.ts
+++ b/src/components/Menu.ts
@@ -4,6 +4,7 @@ import { CLOSE_MENU_EVENT, type CloseMenuEvent } from '../events/CloseMenuEvent'
 import { MENU_CHANGE_EVENT, type MenuChangeEvent } from '../events/MenuChangeEvent';
 import { createCustomEvent } from '../util/EventUtils';
 import { Attribute } from '../util/Attribute';
+import { toggleAttribute } from '../util/CommonUtils';
 
 export interface MenuOptions {
     template?: HTMLTemplateElement;
@@ -97,12 +98,7 @@ export class Menu extends HTMLElement {
             return;
         }
         if (attrName === Attribute.MENU_OPENED) {
-            const hasValue = newValue != null;
-            if (hasValue) {
-                this.removeAttribute('hidden');
-            } else {
-                this.setAttribute('hidden', '');
-            }
+            toggleAttribute(this, Attribute.HIDDEN, newValue == null);
             const changeEvent: MenuChangeEvent = createCustomEvent(MENU_CHANGE_EVENT, { bubbles: true });
             this.dispatchEvent(changeEvent);
         }

--- a/src/components/MenuGroup.ts
+++ b/src/components/MenuGroup.ts
@@ -4,7 +4,7 @@ import { Attribute } from '../util/Attribute';
 import { arrayFind, arrayFindIndex, fromArrayLike, isElement, isHTMLElement, noOp } from '../util/CommonUtils';
 import { CLOSE_MENU_EVENT, type CloseMenuEvent } from '../events/CloseMenuEvent';
 import { TOGGLE_MENU_EVENT, type ToggleMenuEvent } from '../events/ToggleMenuEvent';
-import { KeyCode } from '../util/KeyCode';
+import { isBackKey, KeyCode } from '../util/KeyCode';
 import { createCustomEvent } from '../util/EventUtils';
 import type { MenuChangeEvent } from '../events/MenuChangeEvent';
 import { MENU_CHANGE_EVENT } from '../events/MenuChangeEvent';
@@ -326,16 +326,11 @@ export class MenuGroup extends HTMLElement {
         // Don't handle modifier shortcuts typically used by assistive technology.
         if (event.altKey) return;
 
-        switch (event.keyCode) {
-            case KeyCode.ESCAPE:
-                if (this.closeCurrentMenu()) {
-                    event.preventDefault();
-                    event.stopPropagation();
-                }
-                break;
-            // Any other key press is ignored and passed back to the browser.
-            default:
-                return;
+        if (isBackKey(event.keyCode)) {
+            if (this.closeCurrentMenu()) {
+                event.preventDefault();
+                event.stopPropagation();
+            }
         }
     };
 }

--- a/src/components/PlayButton.ts
+++ b/src/components/PlayButton.ts
@@ -7,6 +7,7 @@ import pauseIcon from '../icons/pause.svg';
 import replayIcon from '../icons/replay.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { Attribute } from '../util/Attribute';
+import { toggleAttribute } from '../util/CommonUtils';
 
 const template = document.createElement('template');
 template.innerHTML = buttonTemplate(
@@ -51,11 +52,7 @@ export class PlayButton extends StateReceiverMixin(Button, ['player']) {
     }
 
     set paused(paused: boolean) {
-        if (paused) {
-            this.setAttribute(Attribute.PAUSED, '');
-        } else {
-            this.removeAttribute(Attribute.PAUSED);
-        }
+        toggleAttribute(this, Attribute.PAUSED, paused);
     }
 
     get ended(): boolean {
@@ -63,11 +60,7 @@ export class PlayButton extends StateReceiverMixin(Button, ['player']) {
     }
 
     set ended(ended: boolean) {
-        if (ended) {
-            this.setAttribute(Attribute.ENDED, '');
-        } else {
-            this.removeAttribute(Attribute.ENDED);
-        }
+        toggleAttribute(this, Attribute.ENDED, ended);
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -252,6 +252,10 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
     }
 
     private readonly _onKeyDown = (e: KeyboardEvent): void => {
+        this.handleKeyDown_(e);
+    };
+
+    protected handleKeyDown_(e: KeyboardEvent) {
         if (this.deviceType === 'tv' && isArrowKey(e.keyCode)) {
             // On TV devices, only allow left/right arrow keys to move the slider.
             if (e.keyCode === KeyCode.LEFT || e.keyCode === KeyCode.RIGHT) {
@@ -263,5 +267,5 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
                 e.preventDefault();
             }
         }
-    };
+    }
 }

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -2,6 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import rangeCss from './Range.css';
 import { Attribute } from '../util/Attribute';
 import { ColorStops } from '../util/ColorStops';
+import { toggleAttribute } from '../util/CommonUtils';
 
 export interface RangeOptions {
     template: HTMLTemplateElement;
@@ -78,11 +79,7 @@ export abstract class Range extends HTMLElement {
     }
 
     set disabled(disabled: boolean) {
-        if (disabled) {
-            this.setAttribute(Attribute.DISABLED, '');
-        } else {
-            this.removeAttribute(Attribute.DISABLED);
-        }
+        toggleAttribute(this, Attribute.DISABLED, disabled);
     }
 
     /**
@@ -142,11 +139,7 @@ export abstract class Range extends HTMLElement {
         const hasValue = newValue != null;
         if (attrName === Attribute.DISABLED) {
             this.setAttribute('aria-disabled', hasValue ? 'true' : 'false');
-            if (hasValue) {
-                this._rangeEl.setAttribute(attrName, newValue);
-            } else {
-                this._rangeEl.removeAttribute(attrName);
-            }
+            toggleAttribute(this._rangeEl, Attribute.DISABLED, hasValue);
         } else if (attrName === Attribute.HIDDEN) {
             if (!hasValue) {
                 this.update();

--- a/src/components/StateReceiverMixin.ts
+++ b/src/components/StateReceiverMixin.ts
@@ -1,4 +1,4 @@
-import { type Constructor, fromArrayLike, isArray, isElement, isHTMLElement, isHTMLSlotElement } from '../util/CommonUtils';
+import { type Constructor, fromArrayLike, getChildren, isArray } from '../util/CommonUtils';
 import type { ChromelessPlayer, THEOplayerError, VideoQuality } from 'theoplayer/chromeless';
 import type { DeviceType } from '../util/DeviceType';
 import type { StreamType } from '../util/StreamType';
@@ -88,14 +88,8 @@ export async function forEachStateReceiverElement(
         callback(element);
     }
     // Check all its children
-    const children: Element[] = [
-        // Element.children does not exist for SVG elements in Internet Explorer.
-        // Assume those won't contain any state receivers.
-        ...(isHTMLElement(element) ? fromArrayLike(element.children) : []),
-        ...(element.shadowRoot ? fromArrayLike(element.shadowRoot.children) : []),
-        ...(isHTMLSlotElement(element) ? element.assignedNodes().filter(isElement) : [])
-    ];
+    const children = getChildren(element);
     if (children.length > 0) {
-        await Promise.all(children.map((child) => forEachStateReceiverElement(child, playerElement, callback)));
+        await Promise.all(fromArrayLike(children).map((child) => forEachStateReceiverElement(child, playerElement, callback)));
     }
 }

--- a/src/components/StateReceiverMixin.ts
+++ b/src/components/StateReceiverMixin.ts
@@ -1,5 +1,6 @@
 import { type Constructor, fromArrayLike, isArray, isElement, isHTMLElement, isHTMLSlotElement } from '../util/CommonUtils';
 import type { ChromelessPlayer, THEOplayerError, VideoQuality } from 'theoplayer/chromeless';
+import type { DeviceType } from '../util/DeviceType';
 import type { StreamType } from '../util/StreamType';
 
 /** @internal */
@@ -8,6 +9,7 @@ export const StateReceiverProps = 'theoplayerUiObservedProperties' as const;
 export interface StateReceiverPropertyMap {
     player: ChromelessPlayer | undefined;
     fullscreen: boolean;
+    deviceType: DeviceType;
     streamType: StreamType;
     playbackRate: number;
     activeVideoQuality: VideoQuality | undefined;

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -137,7 +137,9 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
         if (this._player !== undefined) {
             disabled ||= this._player.seekable.length === 0;
         }
-        this.disabled = disabled;
+        if (this.disabled !== disabled) {
+            this.disabled = disabled;
+        }
     };
 
     protected override getAriaLabel(): string {

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -37,7 +37,7 @@ const AD_MARKER_WIDTH = 1;
  *   the {@link PreviewThumbnail | preview thumbnail}.
  * @group Components
  */
-export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType']) {
+export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType', 'deviceType']) {
     static get observedAttributes() {
         return [...Range.observedAttributes, Attribute.SHOW_AD_MARKERS];
     }

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -14,6 +14,7 @@ import './PreviewThumbnail';
 import './PreviewTimeDisplay';
 import { isLinearAd } from '../util/AdUtils';
 import type { ColorStops } from '../util/ColorStops';
+import { KeyCode } from '../util/KeyCode';
 
 const template = document.createElement('template');
 template.innerHTML = rangeTemplate(timeRangeHtml, timeRangeCss);
@@ -306,6 +307,19 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
     private readonly _onAdChange = () => {
         this.update();
     };
+
+    protected override handleKeyDown_(e: KeyboardEvent) {
+        super.handleKeyDown_(e);
+        if (this.deviceType === 'tv' && e.keyCode === KeyCode.ENTER) {
+            if (this._player !== undefined) {
+                if (this._player.paused) {
+                    this._player.play();
+                } else {
+                    this._player.pause();
+                }
+            }
+        }
+    }
 }
 
 customElements.define('theoplayer-time-range', TimeRange);

--- a/src/components/TrackRadioGroup.ts
+++ b/src/components/TrackRadioGroup.ts
@@ -8,7 +8,7 @@ import { MediaTrackRadioButton } from './MediaTrackRadioButton';
 import { TextTrackRadioButton } from './TextTrackRadioButton';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { TextTrackOffRadioButton } from './TextTrackOffRadioButton';
-import { fromArrayLike } from '../util/CommonUtils';
+import { fromArrayLike, toggleAttribute } from '../util/CommonUtils';
 import { createEvent } from '../util/EventUtils';
 
 const template = document.createElement('template');
@@ -95,11 +95,7 @@ export class TrackRadioGroup extends StateReceiverMixin(HTMLElement, ['player'])
     }
 
     set showOffButton(value: boolean) {
-        if (value) {
-            this.setAttribute(Attribute.SHOW_OFF, '');
-        } else {
-            this.removeAttribute(Attribute.SHOW_OFF);
-        }
+        toggleAttribute(this, Attribute.SHOW_OFF, value);
     }
 
     get player(): ChromelessPlayer | undefined {

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -16,7 +16,7 @@ function formatAsPercentString(value: number, max: number) {
  *
  * @group Components
  */
-export class VolumeRange extends StateReceiverMixin(Range, ['player']) {
+export class VolumeRange extends StateReceiverMixin(Range, ['player', 'deviceType']) {
     private _player: ChromelessPlayer | undefined;
 
     constructor() {

--- a/src/util/Attribute.ts
+++ b/src/util/Attribute.ts
@@ -7,6 +7,7 @@ export enum Attribute {
     FLUID = 'fluid',
     DEVICE_TYPE = 'device-type',
     MOBILE = 'mobile',
+    TV = 'tv',
     MOBILE_ONLY = 'mobile-only',
     MOBILE_HIDDEN = 'mobile-hidden',
     USER_IDLE = 'user-idle',

--- a/src/util/Attribute.ts
+++ b/src/util/Attribute.ts
@@ -5,6 +5,7 @@ export enum Attribute {
     MUTED = 'muted',
     FULLSCREEN = 'fullscreen',
     FLUID = 'fluid',
+    DEVICE_TYPE = 'device-type',
     MOBILE = 'mobile',
     MOBILE_ONLY = 'mobile-only',
     MOBILE_HIDDEN = 'mobile-hidden',

--- a/src/util/CommonUtils.ts
+++ b/src/util/CommonUtils.ts
@@ -107,3 +107,11 @@ export function containsComposedNode(rootNode: Node, childNode: Node): boolean {
     }
     return false;
 }
+
+export function toggleAttribute(element: Element, attribute: string, enabled: boolean): void {
+    if (enabled) {
+        element.setAttribute(attribute, '');
+    } else {
+        element.removeAttribute(attribute);
+    }
+}

--- a/src/util/CommonUtils.ts
+++ b/src/util/CommonUtils.ts
@@ -141,15 +141,19 @@ export function toggleAttribute(element: Element, attribute: string, enabled: bo
 export function getChildren(element: Element): ArrayLike<Element> {
     if (element.shadowRoot) {
         return element.shadowRoot.children;
-    } else if (isHTMLSlotElement(element)) {
-        return element.assignedNodes().filter(isElement);
-    } else if (isHTMLElement(element)) {
+    }
+    if (isHTMLSlotElement(element)) {
+        const assignedNodes = element.assignedNodes();
+        if (assignedNodes.length > 0) {
+            return assignedNodes.filter(isElement);
+        }
+    }
+    if (isHTMLElement(element)) {
         // Element.children does not exist for SVG elements in Internet Explorer.
         // Assume those won't contain any state receivers.
         return element.children;
-    } else {
-        return [];
     }
+    return [];
 }
 
 export function getFocusableChildren(element: HTMLElement): HTMLElement[] {

--- a/src/util/CommonUtils.ts
+++ b/src/util/CommonUtils.ts
@@ -69,6 +69,28 @@ export function arrayRemoveAt<T>(array: T[], index: number): void {
     array.splice(index, 1);
 }
 
+export type Comparator<T, U = T> = (a: T, b: U) => number;
+
+export function arrayMinByKey<T>(array: ReadonlyArray<T>, keySelector: (element: T) => number): T | undefined {
+    return arrayMinBy(array, (first, second) => keySelector(first) - keySelector(second));
+}
+
+export function arrayMaxByKey<T>(array: ReadonlyArray<T>, keySelector: (element: T) => number): T | undefined {
+    return arrayMaxBy(array, (first, second) => keySelector(first) - keySelector(second));
+}
+
+export function arrayMinBy<T>(array: ReadonlyArray<T>, comparator: Comparator<T>): T | undefined {
+    if (array.length === 0) {
+        return undefined;
+    }
+    return array.reduce((first, second) => (comparator(first, second) <= 0 ? first : second));
+}
+
+export function arrayMaxBy<T>(array: ReadonlyArray<T>, comparator: Comparator<T>): T | undefined {
+    const minComparator = (a: T, b: T) => comparator(b, a);
+    return arrayMinBy(array, minComparator);
+}
+
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
 export const stringStartsWith: (string: string, search: string) => boolean =
     typeof String.prototype.startsWith === 'function'
@@ -128,4 +150,51 @@ export function getChildren(element: Element): ArrayLike<Element> {
     } else {
         return [];
     }
+}
+
+export function getFocusableChildren(element: HTMLElement): HTMLElement[] {
+    const result: HTMLElement[] = [];
+    collectFocusableChildren(element, result);
+    return result;
+}
+
+function collectFocusableChildren(element: Element, result: HTMLElement[]) {
+    if (!isHTMLElement(element)) {
+        return;
+    }
+    if (element.hasAttribute('tabindex') && Number(element.getAttribute('tabindex')) >= 0) {
+        result.push(element);
+        return;
+    }
+    switch (element.tagName.toLowerCase()) {
+        case 'button':
+        case 'input':
+        case 'textarea':
+        case 'select':
+        case 'details': {
+            result.push(element);
+            break;
+        }
+        case 'a': {
+            if ((element as HTMLAnchorElement).href) {
+                result.push(element);
+            }
+            break;
+        }
+        default: {
+            const children = getChildren(element);
+            for (let i = 0; i < children.length; i++) {
+                collectFocusableChildren(children[i], result);
+            }
+            break;
+        }
+    }
+}
+
+export function getActiveElement(): Element | null {
+    let activeElement = document.activeElement;
+    while (activeElement?.shadowRoot?.activeElement) {
+        activeElement = activeElement.shadowRoot.activeElement;
+    }
+    return activeElement;
 }

--- a/src/util/CommonUtils.ts
+++ b/src/util/CommonUtils.ts
@@ -166,6 +166,9 @@ function collectFocusableChildren(element: Element, result: HTMLElement[]) {
     if (!isHTMLElement(element)) {
         return;
     }
+    if (getComputedStyle(element).display === 'none') {
+        return;
+    }
     if (element.hasAttribute('tabindex') && Number(element.getAttribute('tabindex')) >= 0) {
         result.push(element);
         return;

--- a/src/util/CommonUtils.ts
+++ b/src/util/CommonUtils.ts
@@ -115,3 +115,17 @@ export function toggleAttribute(element: Element, attribute: string, enabled: bo
         element.removeAttribute(attribute);
     }
 }
+
+export function getChildren(element: Element): ArrayLike<Element> {
+    if (element.shadowRoot) {
+        return element.shadowRoot.children;
+    } else if (isHTMLSlotElement(element)) {
+        return element.assignedNodes().filter(isElement);
+    } else if (isHTMLElement(element)) {
+        // Element.children does not exist for SVG elements in Internet Explorer.
+        // Assume those won't contain any state receivers.
+        return element.children;
+    } else {
+        return [];
+    }
+}

--- a/src/util/DeviceType.ts
+++ b/src/util/DeviceType.ts
@@ -1,0 +1,1 @@
+export type DeviceType = 'desktop' | 'mobile';

--- a/src/util/DeviceType.ts
+++ b/src/util/DeviceType.ts
@@ -1,1 +1,1 @@
-export type DeviceType = 'desktop' | 'mobile';
+export type DeviceType = 'desktop' | 'mobile' | 'tv';

--- a/src/util/Environment.ts
+++ b/src/util/Environment.ts
@@ -23,3 +23,14 @@ export function isMobile(): boolean {
     }
     return /Android|iPhone|iPad|iPod|Mobile Safari|Windows Phone/i.test(userAgent);
 }
+
+export function isTv(): boolean {
+    if (typeof navigator !== 'object') {
+        return false;
+    }
+    const userAgent = navigator.userAgent;
+    if (!userAgent) {
+        return false;
+    }
+    return /\b(tv|smart-tv|smarttv|appletv|crkey|googletv|hbbtv|pov_tv|roku|viera|nettv|philipstv)\b/i.test(userAgent);
+}

--- a/src/util/GeometryUtils.ts
+++ b/src/util/GeometryUtils.ts
@@ -64,6 +64,10 @@ export class Rectangle implements DOMRect {
         return new Rectangle(x, y, width, height);
     }
 
+    snapToPixels(): Rectangle {
+        return new Rectangle(Math.round(this.x), Math.round(this.y), Math.round(this.width), Math.round(this.height));
+    }
+
     clone(): Rectangle {
         return new Rectangle(this.x, this.y, this.width, this.height);
     }

--- a/src/util/KeyCode.ts
+++ b/src/util/KeyCode.ts
@@ -1,11 +1,11 @@
 export enum KeyCode {
-    DOWN = 40,
-    LEFT = 37,
-    RIGHT = 39,
-    SPACE = 32,
     ENTER = 13,
-    UP = 38,
-    HOME = 36,
+    ESCAPE = 27,
+    SPACE = 32,
     END = 35,
-    ESCAPE = 27
+    HOME = 36,
+    LEFT = 37,
+    UP = 38,
+    RIGHT = 39,
+    DOWN = 40
 }

--- a/src/util/KeyCode.ts
+++ b/src/util/KeyCode.ts
@@ -8,16 +8,20 @@ export enum KeyCode {
     UP = 38,
     RIGHT = 39,
     DOWN = 40,
+    // Multiple back key configurations depending on the platform
+    // https://suite.st/docs/faq/tv-specific-keys-in-browser/
+    BACK_SAMSUNG = 88,
+    BACK_WEBOS = 461,
     BACK_TIZEN = 10009
 }
 
 export type ArrowKeyCode = KeyCode.LEFT | KeyCode.UP | KeyCode.RIGHT | KeyCode.DOWN;
-export type BackKeyCode = KeyCode.BACK_TIZEN | KeyCode.ESCAPE;
+export type BackKeyCode = KeyCode.BACK_TIZEN | KeyCode.ESCAPE | KeyCode.BACK_SAMSUNG | KeyCode.BACK_WEBOS;
 
 export function isArrowKey(keyCode: number): keyCode is ArrowKeyCode {
     return KeyCode.LEFT <= keyCode && keyCode <= KeyCode.DOWN;
 }
 
 export function isBackKey(keyCode: number): keyCode is BackKeyCode {
-    return keyCode === KeyCode.BACK_TIZEN || keyCode === KeyCode.ESCAPE;
+    return keyCode === KeyCode.BACK_TIZEN || keyCode === KeyCode.ESCAPE || keyCode === KeyCode.BACK_SAMSUNG || keyCode === KeyCode.BACK_WEBOS;
 }

--- a/src/util/KeyCode.ts
+++ b/src/util/KeyCode.ts
@@ -9,3 +9,9 @@ export enum KeyCode {
     RIGHT = 39,
     DOWN = 40
 }
+
+export type ArrowKeyCode = KeyCode.LEFT | KeyCode.UP | KeyCode.RIGHT | KeyCode.DOWN;
+
+export function isArrowKey(keyCode: number): keyCode is ArrowKeyCode {
+    return KeyCode.LEFT <= keyCode && keyCode <= KeyCode.DOWN;
+}

--- a/src/util/KeyCode.ts
+++ b/src/util/KeyCode.ts
@@ -8,11 +8,16 @@ export enum KeyCode {
     UP = 38,
     RIGHT = 39,
     DOWN = 40,
-    BACK = 10009
+    BACK_TIZEN = 10009
 }
 
 export type ArrowKeyCode = KeyCode.LEFT | KeyCode.UP | KeyCode.RIGHT | KeyCode.DOWN;
+export type BackKeyCode = KeyCode.BACK_TIZEN | KeyCode.ESCAPE;
 
 export function isArrowKey(keyCode: number): keyCode is ArrowKeyCode {
     return KeyCode.LEFT <= keyCode && keyCode <= KeyCode.DOWN;
+}
+
+export function isBackKey(keyCode: number): keyCode is BackKeyCode {
+    return keyCode === KeyCode.BACK_TIZEN || keyCode === KeyCode.ESCAPE;
 }

--- a/src/util/KeyCode.ts
+++ b/src/util/KeyCode.ts
@@ -7,7 +7,8 @@ export enum KeyCode {
     LEFT = 37,
     UP = 38,
     RIGHT = 39,
-    DOWN = 40
+    DOWN = 40,
+    BACK = 10009
 }
 
 export type ArrowKeyCode = KeyCode.LEFT | KeyCode.UP | KeyCode.RIGHT | KeyCode.DOWN;

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -4,7 +4,7 @@ import { Rectangle } from './GeometryUtils';
 
 export function navigateByArrowKey(container: HTMLElement, children: HTMLElement[], key: ArrowKeyCode): boolean {
     const focusedChild = getActiveElement();
-    if (!focusedChild || children.indexOf(focusedChild as HTMLElement) < 0) {
+    if (!focusedChild) {
         // TODO Default focus?
         if (children.length > 0) {
             children[0].focus();

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -2,13 +2,21 @@ import { type ArrowKeyCode, KeyCode } from './KeyCode';
 import { arrayMinByKey, getActiveElement } from './CommonUtils';
 import { Rectangle } from './GeometryUtils';
 
-export function navigateByArrowKey(container: HTMLElement, children: HTMLElement[], key: ArrowKeyCode): boolean {
+export function getFocusedChild(children: HTMLElement[]): Element | null {
     const focusedChild = getActiveElement();
     if (!focusedChild || focusedChild === document.body) {
         if (children.length > 0) {
             children[0].focus();
-            return true;
+            return children[0];
         }
+        return null;
+    }
+    return focusedChild;
+}
+
+export function navigateByArrowKey(container: HTMLElement, children: HTMLElement[], key: ArrowKeyCode): boolean {
+    const focusedChild = getFocusedChild(children);
+    if (focusedChild === null) {
         return false;
     }
     const containerRect = Rectangle.fromRect(container.getBoundingClientRect()).snapToPixels();

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -1,9 +1,8 @@
 import { type ArrowKeyCode, KeyCode } from './KeyCode';
-import { arrayMinByKey, getActiveElement, getFocusableChildren } from './CommonUtils';
+import { arrayMinByKey, getActiveElement } from './CommonUtils';
 import { Rectangle } from './GeometryUtils';
 
-export function navigateByArrowKey(container: HTMLElement, key: ArrowKeyCode): boolean {
-    const children = getFocusableChildren(container);
+export function navigateByArrowKey(container: HTMLElement, children: HTMLElement[], key: ArrowKeyCode): boolean {
     const focusedChild = getActiveElement();
     if (!focusedChild || children.indexOf(focusedChild as HTMLElement) < 0) {
         // TODO Default focus?

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -33,11 +33,11 @@ export function navigateByArrowKey(container: HTMLElement, children: HTMLElement
             bounds.left = focusedRect.right;
             bounds.width = containerRect.right - focusedRect.right;
         }
-        candidates = childrenWithRects.filter((x) => bounds.contains(x.rect));
+        candidates = childrenWithRects.filter((x) => bounds.overlaps(x.rect));
         if (candidates.length === 0) {
             bounds.top = containerRect.top;
             bounds.height = containerRect.height;
-            candidates = childrenWithRects.filter((x) => bounds.contains(x.rect));
+            candidates = childrenWithRects.filter((x) => bounds.overlaps(x.rect));
         }
     } else {
         const bounds = focusedRect.clone();
@@ -48,11 +48,11 @@ export function navigateByArrowKey(container: HTMLElement, children: HTMLElement
             bounds.top = focusedRect.bottom;
             bounds.height = containerRect.bottom - focusedRect.bottom;
         }
-        candidates = childrenWithRects.filter((x) => bounds.contains(x.rect));
+        candidates = childrenWithRects.filter((x) => bounds.overlaps(x.rect));
         if (candidates.length === 0) {
             bounds.left = containerRect.left;
             bounds.width = containerRect.width;
-            candidates = childrenWithRects.filter((x) => bounds.contains(x.rect));
+            candidates = childrenWithRects.filter((x) => bounds.overlaps(x.rect));
         }
     }
     // Find the candidate closest to the currently focused child

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -4,8 +4,7 @@ import { Rectangle } from './GeometryUtils';
 
 export function navigateByArrowKey(container: HTMLElement, children: HTMLElement[], key: ArrowKeyCode): boolean {
     const focusedChild = getActiveElement();
-    if (!focusedChild) {
-        // TODO Default focus?
+    if (!focusedChild || focusedChild === document.body) {
         if (children.length > 0) {
             children[0].focus();
             return true;

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -1,10 +1,10 @@
 import { type ArrowKeyCode, KeyCode } from './KeyCode';
-import { arrayMinByKey, getActiveElement } from './CommonUtils';
+import { arrayMinByKey, getActiveElement, isHTMLElement } from './CommonUtils';
 import { Rectangle } from './GeometryUtils';
 
-export function getFocusedChild(children: HTMLElement[]): Element | null {
+export function getFocusedChild(children: HTMLElement[]): HTMLElement | null {
     const focusedChild = getActiveElement();
-    if (!focusedChild || focusedChild === document.body) {
+    if (!focusedChild || focusedChild === document.body || !isHTMLElement(focusedChild)) {
         if (children.length > 0) {
             children[0].focus();
             return children[0];

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -13,13 +13,13 @@ export function navigateByArrowKey(container: HTMLElement, key: ArrowKeyCode): b
         }
         return false;
     }
-    const containerRect = Rectangle.fromRect(container.getBoundingClientRect());
-    const focusedRect = Rectangle.fromRect(focusedChild.getBoundingClientRect());
+    const containerRect = Rectangle.fromRect(container.getBoundingClientRect()).snapToPixels();
+    const focusedRect = Rectangle.fromRect(focusedChild.getBoundingClientRect()).snapToPixels();
     const childrenWithRects = children
         .map(
             (child): ChildWithRect => ({
                 child,
-                rect: child.getBoundingClientRect()
+                rect: Rectangle.fromRect(child.getBoundingClientRect()).snapToPixels()
             })
         )
         .filter((x) => x.rect.width > 0 && x.rect.height > 0);

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -1,0 +1,87 @@
+import { type ArrowKeyCode, KeyCode } from './KeyCode';
+import { arrayMinByKey, getActiveElement, getFocusableChildren } from './CommonUtils';
+import { Rectangle } from './GeometryUtils';
+
+export function navigateByArrowKey(container: HTMLElement, key: ArrowKeyCode): boolean {
+    const children = getFocusableChildren(container);
+    const focusedChild = getActiveElement();
+    if (!focusedChild || children.indexOf(focusedChild as HTMLElement) < 0) {
+        // TODO Default focus?
+        if (children.length > 0) {
+            children[0].focus();
+            return true;
+        }
+        return false;
+    }
+    const containerRect = Rectangle.fromRect(container.getBoundingClientRect());
+    const focusedRect = Rectangle.fromRect(focusedChild.getBoundingClientRect());
+    const childrenWithRects = children
+        .map(
+            (child): ChildWithRect => ({
+                child,
+                rect: child.getBoundingClientRect()
+            })
+        )
+        .filter((x) => x.rect.width > 0 && x.rect.height > 0);
+    // Find focusable children next to the focused child along the key's direction
+    let candidates: ChildWithRect[];
+    if (key === KeyCode.LEFT || key === KeyCode.RIGHT) {
+        const bounds = focusedRect.clone();
+        if (key === KeyCode.LEFT) {
+            bounds.left = containerRect.left;
+            bounds.width = focusedRect.left - containerRect.left;
+        } else {
+            bounds.left = focusedRect.right;
+            bounds.width = containerRect.right - focusedRect.right;
+        }
+        candidates = childrenWithRects.filter((x) => bounds.contains(x.rect));
+        if (candidates.length === 0) {
+            bounds.top = containerRect.top;
+            bounds.height = containerRect.height;
+            candidates = childrenWithRects.filter((x) => bounds.contains(x.rect));
+        }
+    } else {
+        const bounds = focusedRect.clone();
+        if (key === KeyCode.UP) {
+            bounds.top = containerRect.top;
+            bounds.height = focusedRect.top - containerRect.top;
+        } else {
+            bounds.top = focusedRect.bottom;
+            bounds.height = containerRect.bottom - focusedRect.bottom;
+        }
+        candidates = childrenWithRects.filter((x) => bounds.contains(x.rect));
+        if (candidates.length === 0) {
+            bounds.left = containerRect.left;
+            bounds.width = containerRect.width;
+            candidates = childrenWithRects.filter((x) => bounds.contains(x.rect));
+        }
+    }
+    // Find the candidate closest to the currently focused child
+    const closestCandidate = arrayMinByKey(candidates, (x) => manhattanDistanceBetweenRects(x.rect, focusedRect));
+    if (closestCandidate === undefined) {
+        return false;
+    }
+    // Focus it
+    closestCandidate.child.focus();
+    return true;
+}
+
+interface ChildWithRect {
+    child: HTMLElement;
+    rect: DOMRectReadOnly;
+}
+
+function manhattanDistanceBetweenRects(a: DOMRectReadOnly, b: DOMRectReadOnly): number {
+    let distance = 0;
+    if (a.right < b.left) {
+        distance += b.left - a.right;
+    } else if (b.right < a.left) {
+        distance += a.left - b.right;
+    }
+    if (a.bottom < b.top) {
+        distance += b.top - a.bottom;
+    } else if (b.bottom < a.top) {
+        distance += a.top - b.bottom;
+    }
+    return distance;
+}


### PR DESCRIPTION
Initial implementation for #23. 

Added navigation with the TV remote.
Slightly optimized default TV UI.
Increased default idle timeout for TVs.
Some smaller bugfixes.

### Known issues:
Tizen 4.0 and Tizen 5.0 do not work as of now, partly due to a bug in the polyfill. I opened an issue which can be tracked here: https://github.com/webcomponents/polyfills/issues/565
For now, it can be bypassed on Tizen 4.0 by adding the following script BEFORE loading the polyfills: 

    <script nomodule>
        customElements = customElements || {};
        customElements.forcePolyfill = true;
    </script>

For Tizen 5.0 you would need to add the above, but also remove every `nomodule` for the legacy scripts as it will not load them otherwise.

Tizen 2.4 doesn't even show the player at the moment.