### PR TITLE
Allow overriding more CSS properties of default UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     -   Added support for navigating the UI using a TV remote control.
     -   Added a `tv-focus` attribute to specify which UI element should receive the initial focus when showing the controls on a TV.
         In the default UI, initial focus is on the seek bar.
+-   🚀 Allow overriding more CSS properties of `<theoplayer-default-ui>`. ([#42](https://github.com/THEOplayer/web-ui/pull/42))
 
 ## v1.4.0 (2023-10-04)
 

--- a/src/DefaultUI.css
+++ b/src/DefaultUI.css
@@ -34,7 +34,7 @@ theoplayer-ui {
 }
 
 [part='centered-chrome'] * {
-    --theoplayer-control-height: 48px;
+    --theoplayer-control-height: var(--theoplayer-centered-chrome-control-height, 48px);
 }
 
 [part='middle-chrome'] {
@@ -59,7 +59,7 @@ theoplayer-ui {
  * On mobile, put a backdrop color on the entire player when showing controls.
  */
 :host([mobile]) theoplayer-ui {
-    --theoplayer-control-backdrop-background: rgba(0, 0, 0, 0.5);
+    --theoplayer-control-backdrop-background: var(--theoplayer-mobile-control-backdrop-background, rgba(0, 0, 0, 0.5));
 }
 
 /*
@@ -112,12 +112,12 @@ theoplayer-ui {
 }
 
 theoplayer-time-range {
-    --theoplayer-control-height: 12px;
-    --theoplayer-range-track-pointer-background: rgba(255, 255, 255, 0.5);
+    --theoplayer-control-height: var(--theoplayer-time-range-control-height, 12px);
+    --theoplayer-range-track-pointer-background: var(--theoplayer-time-range-track-pointer-background, rgba(255, 255, 255, 0.5));
 }
 
 [part='ad-chrome'] {
-    --theoplayer-control-height: 12px;
+    --theoplayer-control-height: var(--theoplayer-ad-chrome-control-height, 12px);
     align-items: flex-end;
     pointer-events: none;
 }
@@ -144,8 +144,8 @@ theoplayer-ad-skip-button:not([disabled]) {
     /*
      * Make "Skip Ads" text bigger.
      */
-    font-size: calc(1.25 * var(--theoplayer-text-font-size, 14px));
-    line-height: calc(1.25 * var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px)));
+    font-size: var(--theoplayer-ad-skip-font-size, calc(1.25 * var(--theoplayer-text-font-size, 14px)));
+    line-height: var(--theoplayer-ad-skip-line-height, calc(1.25 * var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px))));
     --theoplayer-ad-skip-icon-width: 24px;
     --theoplayer-ad-skip-icon-height: 24px;
 }
@@ -215,7 +215,7 @@ theoplayer-mute-button + theoplayer-volume-range {
     --theoplayer-range-padding-right: 0;
 
     /* Set the internal width so it reveals, not grows */
-    --theoplayer-range-track-width: 70px;
+    --theoplayer-range-track-width: var(--theoplayer-volume-range-track-width, 70px);
     transition: width 0.2s ease-in;
 }
 
@@ -245,5 +245,5 @@ theoplayer-live-button[live] + theoplayer-time-display {
 
 /* Use smaller playback controls while playing an ad */
 theoplayer-ui[playing-ad] .theoplayer-ad-control {
-    --theoplayer-control-height: 16px;
+    --theoplayer-control-height: var(--theoplayer-ad-control-height, 16px);
 }


### PR DESCRIPTION
`<theoplayer-default-ui>` sets some default values for custom CSS properties used by `<theoplayer-ui>`. This adds a way to *override* these values.