### PR TITLE
Support ads while casting to Chromecast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 > -   🏠 Internal
 > -   💅 Polish
 
+## Unreleased
+
+-   🚀 Added support for advertisements while casting to Chromecast. This requires THEOplayer version 6.8.0 or higher.
+
 ## v1.5.0 (2023-11-27)
 
 -   🚀 Added support for smart TVs. ([#40](https://github.com/THEOplayer/web-ui/pull/40))

--- a/docs/_layouts/example.html
+++ b/docs/_layouts/example.html
@@ -29,5 +29,7 @@ layout: page
 <script nomodule src="https://unpkg.com/@webcomponents/webcomponentsjs@2.8.0/webcomponents-bundle.js"></script>
 <script nomodule src="https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.js"></script>
 <script nomodule src="../dist/THEOplayerUI.es5.js"></script>
+<!-- Chromecast -->
+<script async src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js?loadCastFramework=1"></script>
 
 {{ content }}

--- a/src/DefaultUI.css
+++ b/src/DefaultUI.css
@@ -207,6 +207,13 @@ theoplayer-ui:not([has-first-play]) [part='centered-chrome'] :not(theoplayer-pla
     display: none !important;
 }
 
+/*
+ * Hide ad clickthrough button on desktop, unless we're casting
+ */
+theoplayer-ui:not([mobile]):not([casting]) theoplayer-ad-clickthrough-button {
+    display: none !important;
+}
+
 theoplayer-volume-range {
     --theoplayer-range-padding-left: 0;
 }

--- a/src/DefaultUI.css
+++ b/src/DefaultUI.css
@@ -138,14 +138,16 @@ theoplayer-ad-countdown {
 
 theoplayer-ad-skip-button {
     border-right: 0 !important;
-}
-
-theoplayer-ad-skip-button:not([disabled]) {
+    /**
+     * Align skip countdown to the bottom right.
+     */
+    align-items: end;
+    justify-items: end;
     /*
      * Make "Skip Ads" text bigger.
      */
-    font-size: var(--theoplayer-ad-skip-font-size, calc(1.25 * var(--theoplayer-text-font-size, 14px)));
-    line-height: var(--theoplayer-ad-skip-line-height, calc(1.25 * var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px))));
+    --theoplayer-ad-skip-font-size: calc(1.25 * var(--theoplayer-text-font-size, 14px));
+    --theoplayer-ad-skip-line-height: calc(1.25 * var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px)));
     --theoplayer-ad-skip-icon-width: 24px;
     --theoplayer-ad-skip-icon-height: 24px;
 }

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -30,6 +30,8 @@
             <theoplayer-play-button mobile-hidden ad-only class="theoplayer-ad-control"></theoplayer-play-button>
             <theoplayer-mute-button ad-only class="theoplayer-ad-control"></theoplayer-mute-button>
             <theoplayer-time-range show-ad-markers tv-focus class="theoplayer-ad-control"></theoplayer-time-range>
+            <theoplayer-chromecast-button tv-hidden ad-only class="theoplayer-ad-control"></theoplayer-chromecast-button>
+            <theoplayer-fullscreen-button ad-only class="theoplayer-ad-control"></theoplayer-fullscreen-button>
         </theoplayer-control-bar>
         <theoplayer-control-bar ad-hidden>
             <theoplayer-play-button mobile-hidden></theoplayer-play-button>

--- a/src/DefaultUI.html
+++ b/src/DefaultUI.html
@@ -8,7 +8,7 @@
         <theoplayer-airplay-button mobile-only ad-hidden></theoplayer-airplay-button>
         <theoplayer-chromecast-button mobile-only ad-hidden></theoplayer-chromecast-button>
         <slot name="top-control-bar"></slot>
-        <theoplayer-ad-clickthrough-button ad-only mobile-only></theoplayer-ad-clickthrough-button>
+        <theoplayer-ad-clickthrough-button ad-only></theoplayer-ad-clickthrough-button>
     </theoplayer-control-bar>
     <theoplayer-loading-indicator slot="centered-loading" no-auto-hide></theoplayer-loading-indicator>
     <div slot="centered-chrome" part="centered-chrome">

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -89,7 +89,7 @@ const DEFAULT_DVR_THRESHOLD = 60;
  *   and its stream type to be set to "dvr".
  * @attribute `paused` (readonly) - Whether the player is paused. Reflects `ui.player.paused`.
  * @attribute `ended` (readonly) - Whether the player is ended. Reflects `ui.player.ended`.
- * @attribute `casting` (readonly) - Whether the player is ended. Reflects `ui.player.cast.casting`.
+ * @attribute `casting` (readonly) - Whether the player is casting. Reflects `ui.player.cast.casting`.
  * @attribute `playing-ad` (readonly) - Whether the player is playing a linear ad. Reflects `ui.player.ads.playing`.
  * @attribute `has-error` (readonly) - Whether the player has encountered a fatal error.
  * @attribute `has-first-play` (readonly) - Whether the player has (previously) started playback for this stream.

--- a/src/components/ads/AdSkipButton.css
+++ b/src/components/ads/AdSkipButton.css
@@ -23,6 +23,11 @@
 [part='skip'] {
     display: flex;
     align-items: center;
+    /*
+     * Overlay countdown text and skip button, so they'll both contribute to the size of the parent grid.
+     * This avoids a layout shift when the countdown ends and switches to the skip button.
+     * https://dev.to/nhuynh1/overlaying-elements-with-css-grid-is-so-much-cleaner-than-with-position-4hcm
+     */
     grid-row: 1;
     grid-column: 1;
 }

--- a/src/components/ads/AdSkipButton.css
+++ b/src/components/ads/AdSkipButton.css
@@ -1,4 +1,7 @@
 :host {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
     background: var(--theoplayer-ad-skip-background, rgba(0, 0, 0, 0.7));
     color: var(--theoplayer-ad-skip-color, #fff);
     border: var(--theoplayer-ad-skip-border, 1px solid rgba(255, 255, 255, 0.5));
@@ -16,9 +19,17 @@
     border: var(--theoplayer-ad-skip-countdown-border, 1px solid transparent);
 }
 
+[part='countdown'],
 [part='skip'] {
     display: flex;
     align-items: center;
+    grid-row: 1;
+    grid-column: 1;
+}
+
+[part='skip'] {
+    font-size: var(--theoplayer-ad-skip-font-size, var(--theoplayer-text-font-size, 14px));
+    line-height: var(--theoplayer-ad-skip-line-height, var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px)));
 }
 
 [part='skip-icon'] {

--- a/src/components/ads/AdSkipButton.ts
+++ b/src/components/ads/AdSkipButton.ts
@@ -115,15 +115,17 @@ export class AdSkipButton extends StateReceiverMixin(Button, ['player']) {
             // Show countdown.
             const timeToSkip = Math.ceil(skipOffset - currentTime);
             setTextContent(this._countdownEl, `Skip in ${timeToSkip}s`);
-            this._countdownEl.style.display = '';
-            this._skipEl.style.display = 'none';
+            this._countdownEl.style.visibility = 'visible';
+            this._skipEl.style.visibility = 'hidden';
+            this._skipEl.style.pointerEvents = 'none';
             this.style.display = '';
             this.setAttribute(Attribute.DISABLED, '');
             this.setAttribute(Attribute.ARIA_LIVE, 'off');
         } else {
             // Show skip button.
-            this._countdownEl.style.display = 'none';
-            this._skipEl.style.display = '';
+            this._countdownEl.style.visibility = 'hidden';
+            this._skipEl.style.visibility = 'visible';
+            this._skipEl.style.pointerEvents = '';
             this.style.display = '';
             this.removeAttribute(Attribute.DISABLED);
             this.setAttribute(Attribute.ARIA_LIVE, 'polite');


### PR DESCRIPTION
[THEOplayer 6.8.0](https://docs.theoplayer.com/changelog.md#-680-20240115) added support for playing advertisements while connected to Chromecast. This PR makes Web UI aware of that.

This mostly already worked, except that the ad clickthrough button wasn't visible on desktop. We now always show that button if you're casting, regardless of whether you're on desktop or mobile. I tweaked the CSS of that button, so its height doesn't change when it switches from "skip in X seconds" to "skip".

I also added a fullscreen button to the ad UI, in case you would want to play your ads fullscreen. 😛