### PR TITLE
Fix `closeMenu()` when not yet fully upgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 > -   🏠 Internal
 > -   💅 Polish
 
+## Unreleased
+
+-   🐛 Fixed an issue where `<theoplayer-ui>` could throw an error when the player changes sources before all custom elements are properly registered. ([#49](https://github.com/THEOplayer/web-ui/pull/49))
+
 ## v1.6.0 (2024-02-08)
 
 -   🚀 Introducing [Open Video UI for React](https://www.npmjs.com/package/@theoplayer/react-ui). ([#48](https://github.com/THEOplayer/web-ui/pull/48))

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -22,7 +22,6 @@ import { fullscreenAPI } from './util/FullscreenUtils';
 import { Attribute } from './util/Attribute';
 import { isMobile, isTv } from './util/Environment';
 import { Rectangle } from './util/GeometryUtils';
-import './components/GestureReceiver';
 import { PREVIEW_TIME_CHANGE_EVENT, type PreviewTimeChangeEvent } from './events/PreviewTimeChangeEvent';
 import type { StreamType } from './util/StreamType';
 import type { StreamTypeChangeEvent } from './events/StreamTypeChangeEvent';
@@ -35,6 +34,9 @@ import type { DeviceType } from './util/DeviceType';
 import { getFocusedChild, navigateByArrowKey } from './util/KeyboardNavigation';
 import { isArrowKey, isBackKey, KeyCode } from './util/KeyCode';
 import { READY_EVENT } from './events/ReadyEvent';
+
+// Load components used in template
+import './components/GestureReceiver';
 
 const template = document.createElement('template');
 template.innerHTML = `<style>${elementCss}</style>${elementHtml}`;

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -29,8 +29,7 @@ import type { StreamTypeChangeEvent } from './events/StreamTypeChangeEvent';
 import { STREAM_TYPE_CHANGE_EVENT } from './events/StreamTypeChangeEvent';
 import { createCustomEvent } from './util/EventUtils';
 import { getTargetQualities } from './util/TrackUtils';
-import type { MenuGroup } from './components';
-import './components/MenuGroup';
+import { MenuGroup } from './components/MenuGroup';
 import { MENU_CHANGE_EVENT } from './events/MenuChangeEvent';
 import type { DeviceType } from './util/DeviceType';
 import { getFocusedChild, navigateByArrowKey } from './util/KeyboardNavigation';
@@ -378,6 +377,10 @@ export class UIContainer extends HTMLElement {
     connectedCallback(): void {
         shadyCss.styleElement(this);
 
+        if (!(this._menuGroup instanceof MenuGroup)) {
+            customElements.upgrade(this._menuGroup);
+        }
+
         if (!this.hasAttribute(Attribute.DEVICE_TYPE)) {
             const deviceType: DeviceType = isMobile() ? 'mobile' : isTv() ? 'tv' : 'desktop';
             this.setAttribute(Attribute.DEVICE_TYPE, deviceType);
@@ -661,7 +664,8 @@ export class UIContainer extends HTMLElement {
     }
 
     private closeMenu_(): void {
-        this._menuGroup.closeMenu();
+        // Menu group might not be upgraded yet
+        this._menuGroup.closeMenu?.();
         this._menuOpener?.focus();
         this._menuOpener = undefined;
     }

--- a/src/components/LanguageMenu.ts
+++ b/src/components/LanguageMenu.ts
@@ -6,9 +6,11 @@ import { StateReceiverMixin } from './StateReceiverMixin';
 import type { ChromelessPlayer, MediaTrack, TextTrack } from 'theoplayer/chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
+import { toggleAttribute } from '../util/CommonUtils';
+
+// Load components used in template
 import './TrackRadioGroup';
 import './TextTrackStyleMenu';
-import { toggleAttribute } from '../util/CommonUtils';
 
 const template = document.createElement('template');
 template.innerHTML = menuGroupTemplate(languageMenuHtml, languageMenuCss);

--- a/src/components/PlaybackRateMenu.ts
+++ b/src/components/PlaybackRateMenu.ts
@@ -1,6 +1,8 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { Menu, menuTemplate } from './Menu';
 import playbackRateMenuHtml from './PlaybackRateMenu.html';
+
+// Load components used in template
 import './PlaybackRateRadioGroup';
 
 const template = document.createElement('template');

--- a/src/components/RadioGroup.ts
+++ b/src/components/RadioGroup.ts
@@ -3,7 +3,6 @@ import { isArrowKey, KeyCode } from '../util/KeyCode';
 import { RadioButton } from './RadioButton';
 import { createEvent } from '../util/EventUtils';
 import { arrayFind, isElement, noOp, upgradeCustomElementIfNeeded } from '../util/CommonUtils';
-import './RadioButton';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import { Attribute } from '../util/Attribute';
 import type { DeviceType } from '../util/DeviceType';

--- a/src/components/SettingsMenu.ts
+++ b/src/components/SettingsMenu.ts
@@ -2,6 +2,8 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { MenuGroup, menuGroupTemplate } from './MenuGroup';
 import settingsMenuHtml from './SettingsMenu.html';
 import menuTableCss from './MenuTable.css';
+
+// Load components used in template
 import './ActiveQualityDisplay';
 import './PlaybackRateDisplay';
 import './PlaybackRateMenu';

--- a/src/components/TextTrackStyleMenu.ts
+++ b/src/components/TextTrackStyleMenu.ts
@@ -3,6 +3,8 @@ import { MenuGroup, menuGroupTemplate } from './MenuGroup';
 import textTrackStyleMenuHtml from './TextTrackStyleMenu.html';
 import textTrackStyleMenuCss from './TextTrackStyleMenu.css';
 import menuTableCss from './MenuTable.css';
+
+// Load components used in template
 import './TextTrackStyleDisplay';
 import './TextTrackStyleRadioGroup';
 

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -10,11 +10,13 @@ import type { PreviewTimeChangeEvent } from '../events/PreviewTimeChangeEvent';
 import { PREVIEW_TIME_CHANGE_EVENT } from '../events/PreviewTimeChangeEvent';
 import { Attribute } from '../util/Attribute';
 import type { StreamType } from '../util/StreamType';
-import './PreviewThumbnail';
-import './PreviewTimeDisplay';
 import { isLinearAd } from '../util/AdUtils';
 import type { ColorStops } from '../util/ColorStops';
 import { KeyCode } from '../util/KeyCode';
+
+// Load components used in template
+import './PreviewThumbnail';
+import './PreviewTimeDisplay';
 
 const template = document.createElement('template');
 template.innerHTML = rangeTemplate(timeRangeHtml, timeRangeCss);

--- a/src/util/CommonUtils.ts
+++ b/src/util/CommonUtils.ts
@@ -231,3 +231,15 @@ export function getActiveElement(): Element | null {
     }
     return activeElement;
 }
+
+export function upgradeCustomElementIfNeeded(element: Element): Promise<unknown> | undefined {
+    const elementName = element.nodeName.toLowerCase();
+    if (elementName.indexOf('-') >= 0) {
+        if (customElements.get(elementName)) {
+            customElements.upgrade(element);
+        } else {
+            return customElements.whenDefined(elementName);
+        }
+    }
+    return undefined;
+}


### PR DESCRIPTION
When rapidly creating and destroying the UI (such as when using [Webpack's Hot Module Replacement](https://webpack.js.org/concepts/hot-module-replacement/)), I ran into an edge case where `UIContainer._onSourceChange` was called *before* the `<theoplayer-menu-group>` was properly registered. This led to a `TypeError` when [trying to call `closeMenu()` on a non-upgraded element](https://github.com/THEOplayer/web-ui/blob/v1.6.0/src/UIContainer.ts#L664).

This should hopefully fix that.