### PR TITLE
Add React utility hooks

### DIFF
--- a/docs/examples/react.html
+++ b/docs/examples/react.html
@@ -41,7 +41,7 @@ permalink: /examples/react
 
 <script type="text/babel" data-type="module">
     import * as React from 'react';
-    import { useContext, useEffect, useState } from 'react';
+    import { useCallback, useContext, useState, useSyncExternalStore } from 'react';
     import { createRoot } from 'react-dom/client';
     import * as THEOplayerReactUI from '@theoplayer/react-ui';
 
@@ -80,42 +80,41 @@ permalink: /examples/react
 
     // A custom React hook using THEOplayer.
     // This hook returns the player's current time, automatically updating whenever it changes.
+    // (Alternatively, you can use the built-in `useCurrentTime` hook.)
     const useCurrentTime = () => {
         // Retrieve the THEOplayer instance.
         // This will become available as soon as this component is mounted
-        // inside a THEOplayer <DefauLtUI> <UIContainer>.
+        // inside a THEOplayer <DefauLtUI> or <UIContainer>.
         const player = useContext(THEOplayerReactUI.PlayerContext);
         // Keep track of the player's current time.
-        const [time, setTime] = useState(0);
-        useEffect(() => {
-            const onTimeChange = () => {
-                setTime(player.currentTime);
-            };
-            player?.addEventListener(['timeupdate', 'seeking'], onTimeChange);
-            return () => player?.removeEventListener(['timeupdate', 'seeking'], onTimeChange);
-        }, [player]);
-        return time;
+        const subscribe = useCallback((callback) => {
+            player?.addEventListener(['timeupdate', 'seeking', 'seeked'], callback);
+            return () => player?.removeEventListener(['timeupdate', 'seeking', 'seeked'], callback);
+        });
+        return useSyncExternalStore(
+            subscribe,
+            () => player?.currentTime ?? 0,
+            () => 0
+        );
     };
 
     // Returns whether the player has (previously) started playback for this stream.
     // Can be used to show/hide certain initial controls, such as a poster image or a centered play button.
     const useFirstPlay = () => {
-        const player = useContext(THEOplayerReactUI.PlayerContext);
+        const source = THEOplayerReactUI.useSource();
+        const paused = THEOplayerReactUI.usePaused();
         const [firstPlay, setFirstPlay] = useState(false);
-        useEffect(() => {
-            const onPlay = () => {
-                setFirstPlay(true);
-            };
-            const onSourceChange = () => {
-                setFirstPlay(!player.paused);
-            };
-            player?.addEventListener('play', onPlay);
-            player?.addEventListener('sourcechange', onSourceChange);
-            return () => {
-                player?.removeEventListener('play', onPlay);
-                player?.removeEventListener('sourcechange', onSourceChange);
-            };
-        }, [player]);
+
+        // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+        const [prevSource, setPrevSource] = useState(source);
+        if (source !== prevSource) {
+            setPrevSource(source);
+            setFirstPlay(false);
+        }
+        if (!firstPlay && !paused) {
+            setFirstPlay(true);
+        }
+
         return firstPlay;
     };
 

--- a/docs/examples/react.html
+++ b/docs/examples/react.html
@@ -131,7 +131,7 @@ permalink: /examples/react
     // A custom React component using THEOplayer.
     const MyTimeDisplay = () => {
         const time = useCurrentTime();
-        return <span className="my-time-display">{time}</span>;
+        return <span className="my-time-display">{time.toFixed(3)}</span>;
     };
 
     const Spacer = () => {

--- a/docs/examples/react.html
+++ b/docs/examples/react.html
@@ -87,10 +87,13 @@ permalink: /examples/react
         // inside a THEOplayer <DefauLtUI> or <UIContainer>.
         const player = useContext(THEOplayerReactUI.PlayerContext);
         // Keep track of the player's current time.
-        const subscribe = useCallback((callback) => {
-            player?.addEventListener(['timeupdate', 'seeking', 'seeked'], callback);
-            return () => player?.removeEventListener(['timeupdate', 'seeking', 'seeked'], callback);
-        });
+        const subscribe = useCallback(
+            (callback) => {
+                player?.addEventListener(['timeupdate', 'seeking', 'seeked'], callback);
+                return () => player?.removeEventListener(['timeupdate', 'seeking', 'seeked'], callback);
+            },
+            [player]
+        );
         return useSyncExternalStore(
             subscribe,
             () => player?.currentTime ?? 0,

--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -15,6 +15,8 @@
 -   🚀 Added support for loading in Node for static site generation (SSG) or server-side rendering (SSR). ([#50](https://github.com/THEOplayer/web-ui/pull/50))
     -   This allows you to pass React components (such as `<DefaultUI>`, `<UIContainer>` or `<PlayButton>`) to the [Server React DOM APIs](https://react.dev/reference/react-dom/server), or to use them with a framework that supports SSG or SSR (such as Next.js, Remix or Gatsby).
     -   ⚠️ The rendered HTML must still be [hydrated](https://react.dev/reference/react-dom/client/hydrateRoot#hydrating-server-rendered-html) on the client to load the Open Video UI properly. (Usually, this handled automatically by your React framework.)
+-   🚀 Added utility hooks such as `useCurrentTime()`, `usePaused()` and `useVolume()`. ([#51](https://github.com/THEOplayer/web-ui/pull/51))
+    -   See [the API documentation](https://theoplayer.github.io/web-ui/react-api/) for more information.
 
 ## v1.6.0 (2024-02-08)
 

--- a/react/src/DefaultUI.tsx
+++ b/react/src/DefaultUI.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { type PropsWithoutRef, type ReactNode } from 'react';
+import { type PropsWithoutRef, type ReactNode, useState } from 'react';
 import { DefaultUI as DefaultUIElement } from '@theoplayer/web-ui';
 import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { createComponent, type WebComponentProps } from '@lit/react';
@@ -88,7 +88,8 @@ export interface DefaultUIProps extends PropsWithoutRef<Omit<WebComponentProps<D
  */
 export const DefaultUI = (props: DefaultUIProps) => {
     const { title, topControlBar, bottomControlBar, menu, onReady, ...otherProps } = props;
-    const { player, setUi } = usePlayer(onReady);
+    const [ui, setUi] = useState<DefaultUIElement | null>(null);
+    const player = usePlayer(ui, onReady);
     return (
         <RawDefaultUI {...otherProps} ref={setUi}>
             <PlayerContext.Provider value={player}>

--- a/react/src/DefaultUI.tsx
+++ b/react/src/DefaultUI.tsx
@@ -88,9 +88,9 @@ export interface DefaultUIProps extends PropsWithoutRef<Omit<WebComponentProps<D
  */
 export const DefaultUI = (props: DefaultUIProps) => {
     const { title, topControlBar, bottomControlBar, menu, onReady, ...otherProps } = props;
-    const { player, setUi, onReadyHandler } = usePlayer(onReady);
+    const { player, setUi } = usePlayer(onReady);
     return (
-        <RawDefaultUI {...otherProps} ref={setUi} onReady={onReadyHandler}>
+        <RawDefaultUI {...otherProps} ref={setUi}>
             <PlayerContext.Provider value={player}>
                 <Slotted slot="title">{title}</Slotted>
                 <Slotted slot="top-control-bar">{topControlBar}</Slotted>

--- a/react/src/UIContainer.tsx
+++ b/react/src/UIContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { type PropsWithoutRef, type ReactNode } from 'react';
+import { type PropsWithoutRef, type ReactNode, useState } from 'react';
 import { UIContainer as UIContainerElement } from '@theoplayer/web-ui';
 import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import { createComponent, type WebComponentProps } from '@lit/react';
@@ -129,7 +129,8 @@ export interface UIContainerProps extends PropsWithoutRef<WebComponentProps<UICo
  */
 export const UIContainer = (props: UIContainerProps) => {
     const { topChrome, middleChrome, bottomChrome, centeredChrome, centeredLoading, menu, error, onReady, ...otherProps } = props;
-    const { player, setUi } = usePlayer(onReady);
+    const [ui, setUi] = useState<UIContainerElement | null>(null);
+    const player = usePlayer(ui, onReady);
     return (
         <RawUIContainer {...otherProps} ref={setUi}>
             <PlayerContext.Provider value={player}>

--- a/react/src/UIContainer.tsx
+++ b/react/src/UIContainer.tsx
@@ -129,9 +129,9 @@ export interface UIContainerProps extends PropsWithoutRef<WebComponentProps<UICo
  */
 export const UIContainer = (props: UIContainerProps) => {
     const { topChrome, middleChrome, bottomChrome, centeredChrome, centeredLoading, menu, error, onReady, ...otherProps } = props;
-    const { player, setUi, onReadyHandler } = usePlayer(onReady);
+    const { player, setUi } = usePlayer(onReady);
     return (
-        <RawUIContainer {...otherProps} ref={setUi} onReady={onReadyHandler}>
+        <RawUIContainer {...otherProps} ref={setUi}>
             <PlayerContext.Provider value={player}>
                 <Slotted slot="top-chrome">{topChrome}</Slotted>
                 <Slotted slot="middle-chrome">{middleChrome}</Slotted>

--- a/react/src/context.ts
+++ b/react/src/context.ts
@@ -7,7 +7,7 @@ import type { ChromelessPlayer } from 'theoplayer/chromeless';
  * This can be used to access the backing player's state and add event listeners from within a custom React component.
  * The component *must* be a child of {@link DefaultUI} or {@link UIContainer} in order to receive the context.
  * ```jsx
- * import { useContext, useState } from 'react';
+ * import { useCallback, useContext, useSyncExternalStore } from 'react';
  * import { PlayerContext } from '@theoplayer/react-ui';
  *
  * const MyCustomComponent = () => {
@@ -15,17 +15,20 @@ import type { ChromelessPlayer } from 'theoplayer/chromeless';
  *     const player = useContext(PlayerContext);
  *
  *     // Track the paused state of the player
- *     const [paused, setPaused] = useState(player?.paused ?? true);
- *     useEffect(() => {
- *         if (!player) return;
- *         const updatePaused = () => {
- *             setPaused(player.paused);
- *         };
- *         player.addEventListener(['play', 'pause'], updatePaused);
- *         return () => {
- *             player.removeEventListener(['play', 'pause'], updatePaused);
- *         };
- *     }, [player]);
+ *     const subscribePaused = useCallback(
+ *         (callback) => {
+ *             player?.addEventListener(['play', 'pause'], callback);
+ *             return () => {
+ *                 player?.removeEventListener(['play', 'pause'], callback);
+ *             };
+ *         },
+ *         [player]
+ *     );
+ *     const paused = useSyncExternalStore(
+ *         subscribePaused,
+ *         () => player?.paused ?? true,
+ *         () => true
+ *     );
  *
  *     // Show the paused state in your UI
  *     return <p>Player is {paused ? "paused" : "playing"}</p>

--- a/react/src/context.ts
+++ b/react/src/context.ts
@@ -15,7 +15,7 @@ import type { ChromelessPlayer } from 'theoplayer/chromeless';
  *     const player = useContext(PlayerContext);
  *
  *     // Track the paused state of the player
- *     const subscribePaused = useCallback(
+ *     const subscribe = useCallback(
  *         (callback) => {
  *             player?.addEventListener(['play', 'pause'], callback);
  *             return () => {
@@ -25,7 +25,7 @@ import type { ChromelessPlayer } from 'theoplayer/chromeless';
  *         [player]
  *     );
  *     const paused = useSyncExternalStore(
- *         subscribePaused,
+ *         subscribe,
  *         () => player?.paused ?? true,
  *         () => true
  *     );

--- a/react/src/context.ts
+++ b/react/src/context.ts
@@ -30,6 +30,10 @@ import type { ChromelessPlayer } from 'theoplayer/chromeless';
  *         () => true
  *     );
  *
+ *     // Alternatively, you can use the built-in hook:
+ *     // import { usePaused } from '@theoplayer/react-ui';
+ *     // const paused = usePaused();
+ *
  *     // Show the paused state in your UI
  *     return <p>Player is {paused ? "paused" : "playing"}</p>
  * };

--- a/react/src/hooks/index.ts
+++ b/react/src/hooks/index.ts
@@ -1,0 +1,6 @@
+export * from './useCurrentTime';
+export * from './useDuration';
+export * from './useMuted';
+export * from './usePaused';
+export * from './useSource';
+export * from './useVolume';

--- a/react/src/hooks/index.ts
+++ b/react/src/hooks/index.ts
@@ -2,5 +2,6 @@ export * from './useCurrentTime';
 export * from './useDuration';
 export * from './useMuted';
 export * from './usePaused';
+export * from './useSeeking';
 export * from './useSource';
 export * from './useVolume';

--- a/react/src/hooks/useCurrentTime.ts
+++ b/react/src/hooks/useCurrentTime.ts
@@ -1,0 +1,29 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '../context';
+import type { ChromelessPlayer, PlayerEventMap } from 'theoplayer';
+
+const TIME_CHANGE_EVENTS = ['timeupdate', 'seeking', 'seeked', 'emptied'] satisfies ReadonlyArray<keyof PlayerEventMap>;
+
+/**
+ * Returns [the player's current time]{@link ChromelessPlayer.currentTime}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export function useCurrentTime(): number {
+    const player = useContext(PlayerContext);
+    const subscribe = useCallback(
+        (callback: () => void) => {
+            player?.addEventListener(TIME_CHANGE_EVENTS, callback);
+            return () => player?.removeEventListener(TIME_CHANGE_EVENTS, callback);
+        },
+        [player]
+    );
+    return useSyncExternalStore(
+        subscribe,
+        () => (player ? player.currentTime : 0),
+        () => 0
+    );
+}

--- a/react/src/hooks/useCurrentTime.ts
+++ b/react/src/hooks/useCurrentTime.ts
@@ -1,11 +1,11 @@
 import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { PlayerContext } from '../context';
-import type { ChromelessPlayer, PlayerEventMap } from 'theoplayer';
+import type { PlayerEventMap } from 'theoplayer';
 
 const TIME_CHANGE_EVENTS = ['timeupdate', 'seeking', 'seeked', 'emptied'] satisfies ReadonlyArray<keyof PlayerEventMap>;
 
 /**
- * Returns [the player's current time]{@link ChromelessPlayer.currentTime}, automatically updating whenever it changes.
+ * Returns {@link theoplayer!ChromelessPlayer.currentTime | the player's current time}, automatically updating whenever it changes.
  *
  * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
  * or alternatively any other component that provides a {@link PlayerContext}.

--- a/react/src/hooks/useDuration.ts
+++ b/react/src/hooks/useDuration.ts
@@ -1,0 +1,29 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '../context';
+import type { ChromelessPlayer, PlayerEventMap } from 'theoplayer';
+
+const DURATION_CHANGE_EVENTS = ['durationchange', 'emptied'] satisfies ReadonlyArray<keyof PlayerEventMap>;
+
+/**
+ * Returns [the player's duration]{@link ChromelessPlayer.duration}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export function useDuration(): number {
+    const player = useContext(PlayerContext);
+    const subscribe = useCallback(
+        (callback: () => void) => {
+            player?.addEventListener(DURATION_CHANGE_EVENTS, callback);
+            return () => player?.removeEventListener(DURATION_CHANGE_EVENTS, callback);
+        },
+        [player]
+    );
+    return useSyncExternalStore(
+        subscribe,
+        () => (player ? player.duration : NaN),
+        () => NaN
+    );
+}

--- a/react/src/hooks/useDuration.ts
+++ b/react/src/hooks/useDuration.ts
@@ -1,11 +1,11 @@
 import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { PlayerContext } from '../context';
-import type { ChromelessPlayer, PlayerEventMap } from 'theoplayer';
+import type { PlayerEventMap } from 'theoplayer';
 
 const DURATION_CHANGE_EVENTS = ['durationchange', 'emptied'] satisfies ReadonlyArray<keyof PlayerEventMap>;
 
 /**
- * Returns [the player's duration]{@link ChromelessPlayer.duration}, automatically updating whenever it changes.
+ * Returns {@link theoplayer!ChromelessPlayer.duration | the player's duration}, automatically updating whenever it changes.
  *
  * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
  * or alternatively any other component that provides a {@link PlayerContext}.

--- a/react/src/hooks/useMuted.ts
+++ b/react/src/hooks/useMuted.ts
@@ -1,0 +1,27 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '../context';
+import type { ChromelessPlayer } from 'theoplayer';
+
+/**
+ * Returns [the player's muted state]{@link ChromelessPlayer.muted}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export function useMuted(): boolean {
+    const player = useContext(PlayerContext);
+    const subscribe = useCallback(
+        (callback: () => void) => {
+            player?.addEventListener('volumechange', callback);
+            return () => player?.removeEventListener('volumechange', callback);
+        },
+        [player]
+    );
+    return useSyncExternalStore(
+        subscribe,
+        () => (player ? player.muted : false),
+        () => false
+    );
+}

--- a/react/src/hooks/useMuted.ts
+++ b/react/src/hooks/useMuted.ts
@@ -1,9 +1,8 @@
 import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { PlayerContext } from '../context';
-import type { ChromelessPlayer } from 'theoplayer';
 
 /**
- * Returns [the player's muted state]{@link ChromelessPlayer.muted}, automatically updating whenever it changes.
+ * Returns {@link theoplayer!ChromelessPlayer.muted | the player's muted state}, automatically updating whenever it changes.
  *
  * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
  * or alternatively any other component that provides a {@link PlayerContext}.

--- a/react/src/hooks/usePaused.ts
+++ b/react/src/hooks/usePaused.ts
@@ -1,0 +1,29 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '../context';
+import type { ChromelessPlayer, PlayerEventMap } from 'theoplayer';
+
+const PAUSED_CHANGE_EVENTS = ['play', 'pause'] satisfies ReadonlyArray<keyof PlayerEventMap>;
+
+/**
+ * Returns [the player's paused state]{@link ChromelessPlayer.source}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export function usePaused(): boolean {
+    const player = useContext(PlayerContext);
+    const subscribe = useCallback(
+        (callback: () => void) => {
+            player?.addEventListener(PAUSED_CHANGE_EVENTS, callback);
+            return () => player?.removeEventListener(PAUSED_CHANGE_EVENTS, callback);
+        },
+        [player]
+    );
+    return useSyncExternalStore(
+        subscribe,
+        () => (player ? player.paused : true),
+        () => true
+    );
+}

--- a/react/src/hooks/usePaused.ts
+++ b/react/src/hooks/usePaused.ts
@@ -1,11 +1,11 @@
 import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { PlayerContext } from '../context';
-import type { ChromelessPlayer, PlayerEventMap } from 'theoplayer';
+import type { PlayerEventMap } from 'theoplayer';
 
 const PAUSED_CHANGE_EVENTS = ['play', 'pause'] satisfies ReadonlyArray<keyof PlayerEventMap>;
 
 /**
- * Returns [the player's paused state]{@link ChromelessPlayer.source}, automatically updating whenever it changes.
+ * Returns {@link theoplayer!ChromelessPlayer.paused | the player's paused state}, automatically updating whenever it changes.
  *
  * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
  * or alternatively any other component that provides a {@link PlayerContext}.

--- a/react/src/hooks/useSeeking.ts
+++ b/react/src/hooks/useSeeking.ts
@@ -1,0 +1,29 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '../context';
+import type { PlayerEventMap } from 'theoplayer';
+
+const SEEKING_CHANGE_EVENTS = ['seeking', 'seeked', 'emptied'] satisfies ReadonlyArray<keyof PlayerEventMap>;
+
+/**
+ * Returns {@link theoplayer!ChromelessPlayer.seeking | the player's seeking state}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export function useSeeking(): boolean {
+    const player = useContext(PlayerContext);
+    const subscribe = useCallback(
+        (callback: () => void) => {
+            player?.addEventListener(SEEKING_CHANGE_EVENTS, callback);
+            return () => player?.removeEventListener(SEEKING_CHANGE_EVENTS, callback);
+        },
+        [player]
+    );
+    return useSyncExternalStore(
+        subscribe,
+        () => (player ? player.seeking : false),
+        () => false
+    );
+}

--- a/react/src/hooks/useSource.ts
+++ b/react/src/hooks/useSource.ts
@@ -1,0 +1,27 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '../context';
+import type { ChromelessPlayer, SourceDescription } from 'theoplayer';
+
+/**
+ * Returns [the player's source]{@link ChromelessPlayer.source}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export function useSource(): SourceDescription | undefined {
+    const player = useContext(PlayerContext);
+    const subscribe = useCallback(
+        (callback: () => void) => {
+            player?.addEventListener('sourcechange', callback);
+            return () => player?.removeEventListener('sourcechange', callback);
+        },
+        [player]
+    );
+    return useSyncExternalStore(
+        subscribe,
+        () => player?.source,
+        () => undefined
+    );
+}

--- a/react/src/hooks/useSource.ts
+++ b/react/src/hooks/useSource.ts
@@ -1,9 +1,9 @@
 import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { PlayerContext } from '../context';
-import type { ChromelessPlayer, SourceDescription } from 'theoplayer';
+import type { SourceDescription } from 'theoplayer';
 
 /**
- * Returns [the player's source]{@link ChromelessPlayer.source}, automatically updating whenever it changes.
+ * Returns {@link theoplayer!ChromelessPlayer.source | the player's source}, automatically updating whenever it changes.
  *
  * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
  * or alternatively any other component that provides a {@link PlayerContext}.

--- a/react/src/hooks/useVolume.ts
+++ b/react/src/hooks/useVolume.ts
@@ -1,9 +1,8 @@
 import { useCallback, useContext, useSyncExternalStore } from 'react';
 import { PlayerContext } from '../context';
-import type { ChromelessPlayer } from 'theoplayer';
 
 /**
- * Returns [the player's volume]{@link ChromelessPlayer.volume}, automatically updating whenever it changes.
+ * Returns {@link theoplayer!ChromelessPlayer.volume | the player's volume}, automatically updating whenever it changes.
  *
  * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
  * or alternatively any other component that provides a {@link PlayerContext}.

--- a/react/src/hooks/useVolume.ts
+++ b/react/src/hooks/useVolume.ts
@@ -1,0 +1,27 @@
+import { useCallback, useContext, useSyncExternalStore } from 'react';
+import { PlayerContext } from '../context';
+import type { ChromelessPlayer } from 'theoplayer';
+
+/**
+ * Returns [the player's volume]{@link ChromelessPlayer.volume}, automatically updating whenever it changes.
+ *
+ * This hook must only be used in a component mounted inside a {@link DefaultUI} or {@link UIContainer},
+ * or alternatively any other component that provides a {@link PlayerContext}.
+ *
+ * @group Hooks
+ */
+export function useVolume(): number {
+    const player = useContext(PlayerContext);
+    const subscribe = useCallback(
+        (callback: () => void) => {
+            player?.addEventListener('volumechange', callback);
+            return () => player?.removeEventListener('volumechange', callback);
+        },
+        [player]
+    );
+    return useSyncExternalStore(
+        subscribe,
+        () => (player ? player.volume : 1),
+        () => 1
+    );
+}

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -2,3 +2,4 @@ export { PlayerContext } from './context';
 export * from './UIContainer';
 export * from './DefaultUI';
 export * from './components/index';
+export * from './hooks/index';

--- a/react/src/util.ts
+++ b/react/src/util.ts
@@ -1,13 +1,11 @@
-import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import type { DefaultUI as DefaultUIElement, UIContainer as UIContainerElement } from '@theoplayer/web-ui';
 
-export function usePlayer(onReady?: (player: ChromelessPlayer) => void): {
-    player: ChromelessPlayer | undefined;
-    setUi: (ui: DefaultUIElement | UIContainerElement | null) => void;
-} {
-    const [ui, setUi] = useState<DefaultUIElement | UIContainerElement | null>(null);
-
+export function usePlayer(
+    ui: DefaultUIElement | UIContainerElement | null,
+    onReady?: (player: ChromelessPlayer) => void
+): ChromelessPlayer | undefined {
     // Update player when UI is created, or when 'theoplayerready' event fires.
     const subscribeReady = useCallback(
         (callback: () => void) => {
@@ -28,5 +26,5 @@ export function usePlayer(onReady?: (player: ChromelessPlayer) => void): {
         onReady?.(player);
     }, [player, onReady]);
 
-    return { player, setUi };
+    return player;
 }

--- a/react/src/util.ts
+++ b/react/src/util.ts
@@ -1,24 +1,25 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import type { ChromelessPlayer } from 'theoplayer/chromeless';
 import type { DefaultUI as DefaultUIElement, UIContainer as UIContainerElement } from '@theoplayer/web-ui';
 
 export function usePlayer(onReady?: (player: ChromelessPlayer) => void): {
     player: ChromelessPlayer | undefined;
     setUi: (ui: DefaultUIElement | UIContainerElement | null) => void;
-    onReadyHandler: (event: Event) => void;
 } {
     const [ui, setUi] = useState<DefaultUIElement | UIContainerElement | null>(null);
-    const [player, setPlayer] = useState<ChromelessPlayer | undefined>(undefined);
 
     // Update player when UI is created, or when 'theoplayerready' event fires.
-    useEffect(() => {
-        setPlayer(ui?.player);
-    }, [ui]);
-    const onReadyHandler = useCallback(
-        (_event: Event) => {
-            setPlayer(ui?.player);
+    const subscribeReady = useCallback(
+        (callback: () => void) => {
+            ui?.addEventListener('theoplayerready', callback);
+            return () => ui?.removeEventListener('theoplayerready', callback);
         },
         [ui]
+    );
+    const player = useSyncExternalStore<ChromelessPlayer | undefined>(
+        subscribeReady,
+        () => ui?.player,
+        () => undefined
     );
 
     // Call onReady once player is available.
@@ -27,5 +28,5 @@ export function usePlayer(onReady?: (player: ChromelessPlayer) => void): {
         onReady?.(player);
     }, [player, onReady]);
 
-    return { player, setUi, onReadyHandler };
+    return { player, setUi };
 }

--- a/react/typedoc.json
+++ b/react/typedoc.json
@@ -17,6 +17,12 @@
   "externalSymbolLinkMappings": {
     "theoplayer": {
       "ChromelessPlayer": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md",
+      "ChromelessPlayer.currentTime": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#currenttime",
+      "ChromelessPlayer.duration": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#duration",
+      "ChromelessPlayer.muted": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#muted",
+      "ChromelessPlayer.paused": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#paused",
+      "ChromelessPlayer.source": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#source",
+      "ChromelessPlayer.volume": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#volume",
       "PlayerConfiguration": "https://docs.theoplayer.com/api-reference/web/theoplayer.playerconfiguration.md",
       "SourceDescription": "https://docs.theoplayer.com/api-reference/web/theoplayer.sourcedescription.md",
       "THEOplayerError": "https://docs.theoplayer.com/api-reference/web/theoplayer.theoplayererror.md",

--- a/react/typedoc.json
+++ b/react/typedoc.json
@@ -21,6 +21,7 @@
       "ChromelessPlayer.duration": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#duration",
       "ChromelessPlayer.muted": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#muted",
       "ChromelessPlayer.paused": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#paused",
+      "ChromelessPlayer.seeking": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#seeking",
       "ChromelessPlayer.source": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#source",
       "ChromelessPlayer.volume": "https://docs.theoplayer.com/api-reference/web/theoplayer.chromelessplayer.md#volume",
       "PlayerConfiguration": "https://docs.theoplayer.com/api-reference/web/theoplayer.playerconfiguration.md",


### PR DESCRIPTION
This adds hooks such as `useCurrentTime()`, `usePaused()` and `useVolume()`, to easily access the player's state from within a custom React component.

I also reworked our internals to avoid `useEffect()` as much as possible, using the techniques from [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect).
* Adding/removing event listeners now uses [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore).
* `usePlayer()` now accepts the UI element as a prop, rather than returning a `setUi` callback.