### PR TITLE
Export `version` in public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 > -   🏠 Internal
 > -   💅 Polish
 
+## Unreleased
+
+-   💅 Export `version` in public API. ([#53](https://github.com/THEOplayer/web-ui/pull/53))
+-   💅 Allow importing `@theoplayer/web-ui/package.json`. ([#53](https://github.com/THEOplayer/web-ui/pull/53))
+
 ## v1.7.0 (2024-02-15)
 
 -   🚀 Added support for loading in Node for static site generation (SSG) or server-side rendering (SSR). ([#50](https://github.com/THEOplayer/web-ui/pull/50))

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-inject": "^5.0.5",
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-virtual": "^3.0.2",
         "@rollup/pluginutils": "^5.0.4",
@@ -911,6 +912,26 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.1.tgz",
@@ -975,9 +996,9 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.4.tgz",
-      "integrity": "sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -988,7 +1009,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0"
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -5556,6 +5577,7 @@
         "@theoplayer/web-ui": "^1.7.0"
       },
       "devDependencies": {
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-replace": "^5.0.5",
         "@swc/cli": "^0.1.62",
@@ -5986,6 +6008,15 @@
         "magic-string": "^0.30.3"
       }
     },
+    "@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.1.0"
+      }
+    },
     "@rollup/plugin-node-resolve": {
       "version": "15.2.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.1.tgz",
@@ -6018,9 +6049,9 @@
       "requires": {}
     },
     "@rollup/pluginutils": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.4.tgz",
-      "integrity": "sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
       "dev": true,
       "requires": {
         "@types/estree": "^1.0.0",
@@ -6172,6 +6203,7 @@
       "version": "file:react",
       "requires": {
         "@lit/react": "^1.0.3",
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-replace": "^5.0.5",
         "@swc/cli": "^0.1.62",
@@ -6197,6 +6229,7 @@
       "requires": {
         "@lit-labs/ssr-dom-shim": "^1.2.0",
         "@rollup/plugin-inject": "^5.0.5",
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^15.2.1",
         "@rollup/plugin-virtual": "^3.0.2",
         "@rollup/pluginutils": "^5.0.4",
@@ -6630,6 +6663,15 @@
             "magic-string": "^0.30.3"
           }
         },
+        "@rollup/plugin-json": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+          "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+          "dev": true,
+          "requires": {
+            "@rollup/pluginutils": "^5.1.0"
+          }
+        },
         "@rollup/plugin-node-resolve": {
           "version": "15.2.1",
           "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.2.1.tgz",
@@ -6662,9 +6704,9 @@
           "requires": {}
         },
         "@rollup/pluginutils": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.4.tgz",
-          "integrity": "sha512-0KJnIoRI8A+a1dqOYLxH8vBf8bphDmty5QvIm2hqm7oFCFYKCAZWWd2hXgMibaPsNDhI0AtpYfQZJG47pt/k4g==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+          "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
           "dev": true,
           "requires": {
             "@types/estree": "^1.0.0",
@@ -6816,6 +6858,7 @@
           "version": "file:react",
           "requires": {
             "@lit/react": "^1.0.3",
+            "@rollup/plugin-json": "^6.1.0",
             "@rollup/plugin-node-resolve": "^15.2.1",
             "@rollup/plugin-replace": "^5.0.5",
             "@swc/cli": "^0.1.62",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
       "import": "./dist/THEOplayerUI.es5.mjs",
       "default": "./dist/THEOplayerUI.es5.js"
     },
-    "./dist/*": "./dist/*"
+    "./dist/*": "./dist/*",
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-inject": "^5.0.5",
+    "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-virtual": "^3.0.2",
     "@rollup/pluginutils": "^5.0.4",

--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -13,6 +13,8 @@
 ## Unreleased
 
 -   🐛 Fix "Warning: useLayoutEffect does nothing on the server" when using `@theoplayer/react-ui` in Node. ([#52](https://github.com/THEOplayer/web-ui/pull/52))
+-   💅 Export `version` in public API. ([#53](https://github.com/THEOplayer/web-ui/pull/53))
+-   💅 Allow importing `@theoplayer/react-ui/package.json`. ([#53](https://github.com/THEOplayer/web-ui/pull/53))
 
 ## v1.7.0 (2024-02-15)
 

--- a/react/package.json
+++ b/react/package.json
@@ -60,6 +60,7 @@
     "theoplayer": "^6"
   },
   "devDependencies": {
+    "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-replace": "^5.0.5",
     "@swc/cli": "^0.1.62",

--- a/react/package.json
+++ b/react/package.json
@@ -16,7 +16,9 @@
       "import": "./dist/THEOplayerReactUI.es5.mjs",
       "default": "./dist/THEOplayerReactUI.es5.js"
     },
-    "./dist/*": "./dist/*"
+    "./dist/*": "./dist/*",
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   },
   "files": [
     "dist/",

--- a/react/rollup.config.mjs
+++ b/react/rollup.config.mjs
@@ -49,7 +49,7 @@ export default (cliArgs) => {
                 banner,
                 footer: `export as namespace ${umdName};`
             },
-            plugins: [nodeResolve(), json(), dts()]
+            plugins: [nodeResolve(), dts()]
         }
     ]);
 };

--- a/react/rollup.config.mjs
+++ b/react/rollup.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from 'rollup';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
+import json from '@rollup/plugin-json';
 import { minify, swc } from 'rollup-plugin-swc3';
 import * as path from 'node:path';
 import { readFile } from 'node:fs/promises';
@@ -48,7 +49,7 @@ export default (cliArgs) => {
                 banner,
                 footer: `export as namespace ${umdName};`
             },
-            plugins: [nodeResolve(), dts()]
+            plugins: [nodeResolve(), json(), dts()]
         }
     ]);
 };
@@ -106,6 +107,7 @@ function jsPlugins({ es5 = false, module = false, production = false, sourcemap 
                 }
             }),
         nodeResolve(),
+        json(),
         // Transpile TypeScript.
         swc({
             include: './src/**',

--- a/react/src/index.ts
+++ b/react/src/index.ts
@@ -3,3 +3,4 @@ export * from './UIContainer';
 export * from './DefaultUI';
 export * from './components/index';
 export * from './hooks/index';
+export * from './version';

--- a/react/src/version.ts
+++ b/react/src/version.ts
@@ -1,4 +1,6 @@
+import { version as packageVersion } from '../package.json';
+
 /**
  * The version of Open Video UI for React.
  */
-export { version } from '../package.json';
+export const version: string = packageVersion;

--- a/react/src/version.ts
+++ b/react/src/version.ts
@@ -1,0 +1,4 @@
+/**
+ * The version of Open Video UI for React.
+ */
+export { version } from '../package.json';

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -46,7 +46,7 @@ export default (cliArgs) => {
                 footer: `export as namespace ${umdName};`
             },
             external: [theoplayerModule],
-            plugins: [json(), dts()]
+            plugins: [dts()]
         }
     ]);
 };

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,6 +11,7 @@ import { string } from 'rollup-plugin-string';
 import dts from 'rollup-plugin-dts';
 import inject from '@rollup/plugin-inject';
 import virtual from '@rollup/plugin-virtual';
+import json from '@rollup/plugin-json';
 
 const fileName = 'THEOplayerUI';
 const umdName = 'THEOplayerUI';
@@ -45,7 +46,7 @@ export default (cliArgs) => {
                 footer: `export as namespace ${umdName};`
             },
             external: [theoplayerModule],
-            plugins: [dts()]
+            plugins: [json(), dts()]
         }
     ]);
 };
@@ -117,6 +118,7 @@ function jsPlugins({ es5 = false, node = false, module = false, production = fal
                 // Remove createTemplate() helper.
                 ['./src/util/TemplateUtils']: `export function createTemplate() { return () => undefined; }`
             }),
+        json(),
         // Run PostCSS on .css files.
         postcss({
             include: './src/**/*.css',

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -27,9 +27,9 @@ const template = createTemplate('theoplayer-default-ui', `<style>${defaultUiCss}
  * ## Usage
  *
  * 1. Create a `<theoplayer-default-ui>` element.
- * 1. Set its `configuration` attribute or property to a valid player configuration.
- * 1. Set its `source` attribute or property to a valid stream source.
- * 1. Optionally, customize the player using CSS custom properties and/or extra controls.
+ * 2. Set its `configuration` attribute or property to a valid player configuration.
+ * 3. Set its `source` attribute or property to a valid stream source.
+ * 4. Optionally, customize the player using CSS custom properties and/or extra controls.
  *
  * ## Customization
  *

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -54,10 +54,10 @@ const DEFAULT_DVR_THRESHOLD = 60;
  * ## Usage
  *
  * 1. Create a `<theoplayer-ui>` element.
- * 1. Place your UI elements as children of the `<theoplayer-ui>`.
+ * 2. Place your UI elements as children of the `<theoplayer-ui>`.
  *    Set their `slot` attribute to one of the defined slots (see below) to place them in the layout.
- * 1. Set its `configuration` attribute or property to a valid player configuration.
- * 1. Set its `source` attribute or property to a valid stream source.
+ * 3. Set its `configuration` attribute or property to a valid player configuration.
+ * 4. Set its `source` attribute or property to a valid stream source.
  *
  * ## Customization
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export { type DeviceType } from './util/DeviceType';
 export { type StreamType } from './util/StreamType';
 export { type Constructor } from './util/CommonUtils';
 export { ColorStops } from './util/ColorStops';
+export * from './version';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,4 @@
+/**
+ * The version of Open Video UI for Web.
+ */
+export { version } from '../package.json';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,4 +1,6 @@
+import { version as packageVersion } from '../package.json';
+
 /**
  * The version of Open Video UI for Web.
  */
-export { version } from '../package.json';
+export const version: string = packageVersion;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "es2015",
     "moduleResolution": "bundler",
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipDefaultLibCheck": true,


### PR DESCRIPTION
This allows users to quickly check what version of Open Video UI is running on their webpage.

Also make it possible to import `package.json` from both `@theoplayer/web-ui` and `@theoplayer/react-ui`. This is useful to get the *installed* version of Open Video UI in your web app's build logic.