### PR TITLE
Fix `ui.player.destroy()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ sidebar_custom_props: { 'icon': '📰' }
 > -   🏠 Internal
 > -   💅 Polish
 
+## Unreleased
+
+-   🐛 Fixed `ui.player.destroy()` not working. ([#59](https://github.com/THEOplayer/web-ui/issues/59), [#62](https://github.com/THEOplayer/web-ui/pull/62))
+
 ## v1.8.0 (2024-04-12)
 
 -   💥 **Breaking Change**: This project now requires THEOplayer version 7.0.0 or higher. ([#60](https://github.com/THEOplayer/web-ui/pull/60))

--- a/react/CHANGELOG.md
+++ b/react/CHANGELOG.md
@@ -15,6 +15,10 @@ sidebar_custom_props: { 'icon': '📰' }
 > -   🏠 Internal
 > -   💅 Polish
 
+## Unreleased
+
+-   🐛 Fixed backing THEOplayer not always being destroyed on unmount. ([#59](https://github.com/THEOplayer/web-ui/issues/59), [#62](https://github.com/THEOplayer/web-ui/pull/62))
+
 ## v1.8.0 (2024-04-12)
 
 -   💥 **Breaking Change**: This project now requires THEOplayer version 7.0.0 or higher. ([#60](https://github.com/THEOplayer/web-ui/pull/60))

--- a/react/src/util.ts
+++ b/react/src/util.ts
@@ -26,5 +26,10 @@ export function usePlayer(
         onReady?.(player);
     }, [player, onReady]);
 
+    // Destroy player on unmount.
+    useEffect(() => {
+        return () => player?.destroy();
+    }, [player]);
+
     return player;
 }

--- a/react/src/util.ts
+++ b/react/src/util.ts
@@ -28,7 +28,13 @@ export function usePlayer(
 
     // Destroy player on unmount.
     useEffect(() => {
-        return () => player?.destroy();
+        return () => {
+            try {
+                player?.destroy();
+            } catch {
+                // Ignore, probably already destroyed.
+            }
+        };
     }, [player]);
 
     return player;

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -448,20 +448,7 @@ export class UIContainer extends HTMLElement {
         this._updateError();
         this._updatePausedAndEnded();
         this._updateCasting();
-        this._player.addEventListener('resize', this._updateAspectRatio);
-        this._player.addEventListener(['error', 'sourcechange', 'emptied'], this._updateError);
-        this._player.addEventListener('volumechange', this._updateMuted);
-        this._player.addEventListener('play', this._onPlay);
-        this._player.addEventListener('pause', this._onPause);
-        this._player.addEventListener(['ended', 'emptied'], this._updatePausedAndEnded);
-        this._player.addEventListener(['durationchange', 'sourcechange', 'emptied'], this._updateStreamType);
-        this._player.addEventListener('ratechange', this._updatePlaybackRate);
-        this._player.addEventListener('sourcechange', this._onSourceChange);
-        this._player.theoLive?.addEventListener('publicationloadstart', this._onSourceChange);
-        this._player.videoTracks.addEventListener(['addtrack', 'removetrack', 'change'], this._updateActiveVideoTrack);
-        this._player.cast?.addEventListener('castingchange', this._updateCasting);
-        this._player.addEventListener(['durationchange', 'sourcechange', 'emptied'], this._updatePlayingAd);
-        this._player.ads?.addEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend', 'adskip'], this._updatePlayingAd);
+        this._addPlayerListeners(this._player);
 
         this.dispatchEvent(createCustomEvent(READY_EVENT));
     }
@@ -491,6 +478,7 @@ export class UIContainer extends HTMLElement {
         this.removeEventListener('mouseleave', this._onMouseLeave);
 
         if (this._player) {
+            this._removePlayerListeners(this._player);
             this._player.destroy();
             this._player = undefined;
         }
@@ -1063,6 +1051,49 @@ export class UIContainer extends HTMLElement {
             if (receiver[StateReceiverProps].indexOf('previewTime') >= 0) {
                 receiver.previewTime = this._previewTime;
             }
+        }
+    };
+
+    private _addPlayerListeners(player: ChromelessPlayer): void {
+        player.addEventListener('destroy', this._onDestroy);
+        player.addEventListener('resize', this._updateAspectRatio);
+        player.addEventListener(['error', 'sourcechange', 'emptied'], this._updateError);
+        player.addEventListener('volumechange', this._updateMuted);
+        player.addEventListener('play', this._onPlay);
+        player.addEventListener('pause', this._onPause);
+        player.addEventListener(['ended', 'emptied'], this._updatePausedAndEnded);
+        player.addEventListener(['durationchange', 'sourcechange', 'emptied'], this._updateStreamType);
+        player.addEventListener('ratechange', this._updatePlaybackRate);
+        player.addEventListener('sourcechange', this._onSourceChange);
+        player.theoLive?.addEventListener('publicationloadstart', this._onSourceChange);
+        player.videoTracks.addEventListener(['addtrack', 'removetrack', 'change'], this._updateActiveVideoTrack);
+        player.cast?.addEventListener('castingchange', this._updateCasting);
+        player.addEventListener(['durationchange', 'sourcechange', 'emptied'], this._updatePlayingAd);
+        player.ads?.addEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend', 'adskip'], this._updatePlayingAd);
+    }
+
+    private _removePlayerListeners(player: ChromelessPlayer): void {
+        player.removeEventListener('destroy', this._onDestroy);
+        player.removeEventListener('resize', this._updateAspectRatio);
+        player.removeEventListener(['error', 'sourcechange', 'emptied'], this._updateError);
+        player.removeEventListener('volumechange', this._updateMuted);
+        player.removeEventListener('play', this._onPlay);
+        player.removeEventListener('pause', this._onPause);
+        player.removeEventListener(['ended', 'emptied'], this._updatePausedAndEnded);
+        player.removeEventListener(['durationchange', 'sourcechange', 'emptied'], this._updateStreamType);
+        player.removeEventListener('ratechange', this._updatePlaybackRate);
+        player.removeEventListener('sourcechange', this._onSourceChange);
+        player.theoLive?.removeEventListener('publicationloadstart', this._onSourceChange);
+        player.videoTracks.removeEventListener(['addtrack', 'removetrack', 'change'], this._updateActiveVideoTrack);
+        player.cast?.removeEventListener('castingchange', this._updateCasting);
+        player.removeEventListener(['durationchange', 'sourcechange', 'emptied'], this._updatePlayingAd);
+        player.ads?.removeEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend', 'adskip'], this._updatePlayingAd);
+    }
+
+    private readonly _onDestroy = (): void => {
+        if (this._player) {
+            this._removePlayerListeners(this._player);
+            this._player = undefined;
         }
     };
 }

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1068,10 +1068,11 @@ export class UIContainer extends HTMLElement {
         player.addEventListener(['durationchange', 'sourcechange', 'emptied'], this._updateStreamType);
         player.addEventListener('ratechange', this._updatePlaybackRate);
         player.addEventListener('sourcechange', this._onSourceChange);
+        player.addEventListener(['durationchange', 'sourcechange', 'emptied'], this._updatePlayingAd);
+
         player.theoLive?.addEventListener('publicationloadstart', this._onSourceChange);
         player.videoTracks.addEventListener(['addtrack', 'removetrack', 'change'], this._updateActiveVideoTrack);
         player.cast?.addEventListener('castingchange', this._updateCasting);
-        player.addEventListener(['durationchange', 'sourcechange', 'emptied'], this._updatePlayingAd);
         player.ads?.addEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend', 'adskip'], this._updatePlayingAd);
     }
 
@@ -1086,11 +1087,16 @@ export class UIContainer extends HTMLElement {
         player.removeEventListener(['durationchange', 'sourcechange', 'emptied'], this._updateStreamType);
         player.removeEventListener('ratechange', this._updatePlaybackRate);
         player.removeEventListener('sourcechange', this._onSourceChange);
-        player.theoLive?.removeEventListener('publicationloadstart', this._onSourceChange);
-        player.videoTracks.removeEventListener(['addtrack', 'removetrack', 'change'], this._updateActiveVideoTrack);
-        player.cast?.removeEventListener('castingchange', this._updateCasting);
         player.removeEventListener(['durationchange', 'sourcechange', 'emptied'], this._updatePlayingAd);
-        player.ads?.removeEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend', 'adskip'], this._updatePlayingAd);
+
+        try {
+            player.theoLive?.removeEventListener('publicationloadstart', this._onSourceChange);
+            player.videoTracks.removeEventListener(['addtrack', 'removetrack', 'change'], this._updateActiveVideoTrack);
+            player.cast?.removeEventListener('castingchange', this._updateCasting);
+            player.ads?.removeEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend', 'adskip'], this._updatePlayingAd);
+        } catch {
+            // Ignore errors from accessing player.ads when the player is already destroyed.
+        }
     }
 
     private readonly _onDestroy = (): void => {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -442,7 +442,7 @@ export class UIContainer extends HTMLElement {
         this._updateError();
         this._updatePausedAndEnded();
         this._updateCasting();
-        this._addPlayerListeners(this._player);
+        this.addPlayerListeners_(this._player);
         this.propagatePlayerToAllReceivers_();
 
         this.dispatchEvent(createCustomEvent(READY_EVENT));
@@ -469,7 +469,7 @@ export class UIContainer extends HTMLElement {
         this.removeEventListener('mouseleave', this._onMouseLeave);
 
         if (this._player) {
-            this._removePlayerListeners(this._player);
+            this.removePlayerListeners_(this._player);
             this._player.destroy();
             this._player = undefined;
             this.propagatePlayerToAllReceivers_();
@@ -1057,7 +1057,7 @@ export class UIContainer extends HTMLElement {
         }
     };
 
-    private _addPlayerListeners(player: ChromelessPlayer): void {
+    private addPlayerListeners_(player: ChromelessPlayer): void {
         player.addEventListener('destroy', this._onDestroy);
         player.addEventListener('resize', this._updateAspectRatio);
         player.addEventListener(['error', 'sourcechange', 'emptied'], this._updateError);
@@ -1075,7 +1075,7 @@ export class UIContainer extends HTMLElement {
         player.ads?.addEventListener(['adbreakbegin', 'adbreakend', 'adbegin', 'adend', 'adskip'], this._updatePlayingAd);
     }
 
-    private _removePlayerListeners(player: ChromelessPlayer): void {
+    private removePlayerListeners_(player: ChromelessPlayer): void {
         player.removeEventListener('destroy', this._onDestroy);
         player.removeEventListener('resize', this._updateAspectRatio);
         player.removeEventListener(['error', 'sourcechange', 'emptied'], this._updateError);
@@ -1095,7 +1095,7 @@ export class UIContainer extends HTMLElement {
 
     private readonly _onDestroy = (): void => {
         if (this._player) {
-            this._removePlayerListeners(this._player);
+            this.removePlayerListeners_(this._player);
             this._player = undefined;
             this.propagatePlayerToAllReceivers_();
         }

--- a/src/components/ChromecastDisplay.ts
+++ b/src/components/ChromecastDisplay.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import chromecastDisplayCss from './ChromecastDisplay.css';
 import chromecastIcon from '../icons/chromecast-48px.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/chromeless';
+import type { Chromecast, ChromelessPlayer } from 'theoplayer/chromeless';
 import { setTextContent } from '../util/CommonUtils';
 import { Attribute } from '../util/Attribute';
 import { createTemplate } from '../util/TemplateUtils';
@@ -27,6 +27,7 @@ const CAST_EVENTS = ['statechange'] as const;
 export class ChromecastDisplay extends StateReceiverMixin(HTMLElement, ['player']) {
     private readonly _receiverNameEl: HTMLElement;
     private _player: ChromelessPlayer | undefined;
+    private _castApi: Chromecast | undefined;
 
     constructor() {
         super();
@@ -61,10 +62,15 @@ export class ChromecastDisplay extends StateReceiverMixin(HTMLElement, ['player'
         if (this._player === player) {
             return;
         }
-        this._player?.cast?.chromecast?.removeEventListener(CAST_EVENTS, this._updateFromPlayer);
+        if (this._castApi !== undefined) {
+            this._castApi.removeEventListener(CAST_EVENTS, this._updateFromPlayer);
+        }
         this._player = player;
+        this._castApi = player?.cast?.chromecast;
         this._updateFromPlayer();
-        this._player?.cast?.chromecast?.addEventListener(CAST_EVENTS, this._updateFromPlayer);
+        if (this._castApi !== undefined) {
+            this._castApi.addEventListener(CAST_EVENTS, this._updateFromPlayer);
+        }
     }
 
     private readonly _updateFromPlayer = () => {

--- a/src/components/GestureReceiver.ts
+++ b/src/components/GestureReceiver.ts
@@ -16,6 +16,7 @@ const template = createTemplate('theoplayer-gesture-receiver', `<style>${gesture
  */
 export class GestureReceiver extends StateReceiverMixin(HTMLElement, ['player']) {
     private _player: ChromelessPlayer | undefined;
+    private _playerElement: HTMLElement | undefined;
     private _pointerType: string = '';
 
     constructor() {
@@ -49,14 +50,15 @@ export class GestureReceiver extends StateReceiverMixin(HTMLElement, ['player'])
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.element.removeEventListener('pointerdown', this._onPointerDown);
-            this._player.element.removeEventListener('click', this._onClick);
+        if (this._playerElement !== undefined) {
+            this._playerElement.removeEventListener('pointerdown', this._onPointerDown);
+            this._playerElement.removeEventListener('click', this._onClick);
         }
         this._player = player;
-        if (this._player !== undefined) {
-            this._player.element.addEventListener('pointerdown', this._onPointerDown);
-            this._player.element.addEventListener('click', this._onClick);
+        this._playerElement = player?.element;
+        if (this._playerElement !== undefined) {
+            this._playerElement.addEventListener('pointerdown', this._onPointerDown);
+            this._playerElement.addEventListener('click', this._onClick);
         }
     }
 

--- a/src/components/LanguageMenu.ts
+++ b/src/components/LanguageMenu.ts
@@ -3,7 +3,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import languageMenuHtml from './LanguageMenu.html';
 import languageMenuCss from './LanguageMenu.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, MediaTrack, TextTrack } from 'theoplayer/chromeless';
+import type { ChromelessPlayer, MediaTrack, MediaTrackList, TextTrack, TextTracksList } from 'theoplayer/chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 import { toggleAttribute } from '../util/CommonUtils';
@@ -26,6 +26,8 @@ const TRACK_EVENTS = ['addtrack', 'removetrack'] as const;
  */
 export class LanguageMenu extends StateReceiverMixin(MenuGroup, ['player']) {
     private _player: ChromelessPlayer | undefined;
+    private _audioTrackList: MediaTrackList | undefined;
+    private _textTrackList: TextTracksList | undefined;
 
     static get observedAttributes() {
         return [...MenuGroup.observedAttributes, Attribute.HAS_AUDIO, Attribute.HAS_SUBTITLES];
@@ -44,17 +46,15 @@ export class LanguageMenu extends StateReceiverMixin(MenuGroup, ['player']) {
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.audioTracks.removeEventListener(TRACK_EVENTS, this._updateAudioTracks);
-            this._player.textTracks.removeEventListener(TRACK_EVENTS, this._updateTextTracks);
-        }
+        this._audioTrackList?.removeEventListener(TRACK_EVENTS, this._updateAudioTracks);
+        this._textTrackList?.removeEventListener(TRACK_EVENTS, this._updateTextTracks);
         this._player = player;
+        this._audioTrackList = player?.audioTracks;
+        this._textTrackList = player?.textTracks;
         this._updateAudioTracks();
         this._updateTextTracks();
-        if (this._player !== undefined) {
-            this._player.audioTracks.addEventListener(TRACK_EVENTS, this._updateAudioTracks);
-            this._player.textTracks.addEventListener(TRACK_EVENTS, this._updateTextTracks);
-        }
+        this._audioTrackList?.addEventListener(TRACK_EVENTS, this._updateAudioTracks);
+        this._textTrackList?.addEventListener(TRACK_EVENTS, this._updateTextTracks);
     }
 
     private readonly _updateAudioTracks = (): void => {

--- a/src/components/LanguageMenuButton.ts
+++ b/src/components/LanguageMenuButton.ts
@@ -2,7 +2,7 @@ import { MenuButton } from './MenuButton';
 import { buttonTemplate } from './Button';
 import languageIcon from '../icons/language.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/chromeless';
+import type { ChromelessPlayer, MediaTrackList, TextTracksList } from 'theoplayer/chromeless';
 import { isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 import { toggleAttribute } from '../util/CommonUtils';
@@ -22,6 +22,8 @@ const TRACK_EVENTS = ['addtrack', 'removetrack'] as const;
  */
 export class LanguageMenuButton extends StateReceiverMixin(MenuButton, ['player']) {
     private _player: ChromelessPlayer | undefined;
+    private _audioTrackList: MediaTrackList | undefined;
+    private _textTrackList: TextTracksList | undefined;
 
     constructor() {
         super({ template: template() });
@@ -44,16 +46,14 @@ export class LanguageMenuButton extends StateReceiverMixin(MenuButton, ['player'
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.audioTracks.removeEventListener(TRACK_EVENTS, this._updateTracks);
-            this._player.textTracks.removeEventListener(TRACK_EVENTS, this._updateTracks);
-        }
+        this._audioTrackList?.removeEventListener(TRACK_EVENTS, this._updateTracks);
+        this._textTrackList?.removeEventListener(TRACK_EVENTS, this._updateTracks);
         this._player = player;
+        this._audioTrackList = player?.audioTracks;
+        this._textTrackList = player?.textTracks;
         this._updateTracks();
-        if (this._player !== undefined) {
-            this._player.audioTracks.addEventListener(TRACK_EVENTS, this._updateTracks);
-            this._player.textTracks.addEventListener(TRACK_EVENTS, this._updateTracks);
-        }
+        this._audioTrackList?.addEventListener(TRACK_EVENTS, this._updateTracks);
+        this._textTrackList?.addEventListener(TRACK_EVENTS, this._updateTracks);
     }
 
     private readonly _updateTracks = (): void => {

--- a/src/components/PreviewThumbnail.ts
+++ b/src/components/PreviewThumbnail.ts
@@ -1,7 +1,7 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import previewThumbnailCss from './PreviewThumbnail.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, TextTrack, TextTrackCue, TextTrackCueList } from 'theoplayer/chromeless';
+import type { ChromelessPlayer, TextTrack, TextTrackCue, TextTrackCueList, TextTracksList } from 'theoplayer/chromeless';
 import { arrayFind, noOp } from '../util/CommonUtils';
 import { createTemplate } from '../util/TemplateUtils';
 
@@ -27,6 +27,7 @@ export class PreviewThumbnail extends StateReceiverMixin(HTMLElement, ['player',
     private readonly _thumbnailImageSource: HTMLImageElement;
 
     private _player: ChromelessPlayer | undefined;
+    private _textTrackList: TextTracksList | undefined;
     private _previewTime: number = NaN;
     private _thumbnailTextTrack: TextTrack | undefined;
     private _lastLoadedThumbnailUrl: string | undefined;
@@ -66,14 +67,11 @@ export class PreviewThumbnail extends StateReceiverMixin(HTMLElement, ['player',
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.textTracks.removeEventListener(TRACK_EVENTS, this._updateThumbnailTextTrack);
-        }
+        this._textTrackList?.removeEventListener(TRACK_EVENTS, this._updateThumbnailTextTrack);
         this._player = player;
+        this._textTrackList = player?.textTracks;
         this._updateThumbnailTextTrack();
-        if (this._player !== undefined) {
-            this._player.textTracks.addEventListener(TRACK_EVENTS, this._updateThumbnailTextTrack);
-        }
+        this._textTrackList?.addEventListener(TRACK_EVENTS, this._updateThumbnailTextTrack);
     }
 
     get previewTime(): number {

--- a/src/components/QualityRadioGroup.ts
+++ b/src/components/QualityRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, MediaTrack, Quality, VideoQuality } from 'theoplayer/chromeless';
+import type { ChromelessPlayer, MediaTrack, MediaTrackList, Quality, VideoQuality } from 'theoplayer/chromeless';
 import { arrayFind, fromArrayLike } from '../util/CommonUtils';
 import { QualityRadioButton } from './QualityRadioButton';
 import { createEvent } from '../util/EventUtils';
@@ -24,6 +24,7 @@ const TRACK_EVENTS = ['addtrack', 'removetrack', 'change'] as const;
 export class QualityRadioGroup extends StateReceiverMixin(HTMLElement, ['player']) {
     private readonly _radioGroup: RadioGroup;
     private _player: ChromelessPlayer | undefined;
+    private _videoTracks: MediaTrackList | undefined;
     private _track: MediaTrack | undefined;
 
     constructor() {
@@ -67,14 +68,11 @@ export class QualityRadioGroup extends StateReceiverMixin(HTMLElement, ['player'
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.videoTracks.removeEventListener(TRACK_EVENTS, this._updateTrack);
-        }
+        this._videoTracks?.removeEventListener(TRACK_EVENTS, this._updateTrack);
         this._player = player;
+        this._videoTracks = player?.videoTracks;
         this._updateTrack();
-        if (this._player !== undefined) {
-            this._player.videoTracks.addEventListener(TRACK_EVENTS, this._updateTrack);
-        }
+        this._videoTracks?.addEventListener(TRACK_EVENTS, this._updateTrack);
     }
 
     private readonly _onChange = () => {

--- a/src/components/TextTrackStyleDisplay.ts
+++ b/src/components/TextTrackStyleDisplay.ts
@@ -1,6 +1,6 @@
 import * as shadyCss from '@webcomponents/shadycss';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, EdgeStyle } from 'theoplayer/chromeless';
+import type { ChromelessPlayer, EdgeStyle, TextTrackStyle } from 'theoplayer/chromeless';
 import { Attribute } from '../util/Attribute';
 import { parseColor, toRgb } from '../util/ColorUtils';
 import type { TextTrackStyleOption } from './TextTrackStyleRadioGroup';
@@ -21,6 +21,7 @@ export class TextTrackStyleDisplay extends StateReceiverMixin(HTMLElement, ['pla
 
     private readonly _spanEl: HTMLSpanElement;
     private _player: ChromelessPlayer | undefined;
+    private _textTrackStyle: TextTrackStyle | undefined;
 
     constructor() {
         super();
@@ -67,14 +68,11 @@ export class TextTrackStyleDisplay extends StateReceiverMixin(HTMLElement, ['pla
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.textTrackStyle.removeEventListener('change', this._updateFromPlayer);
-        }
+        this._textTrackStyle?.removeEventListener('change', this._updateFromPlayer);
         this._player = player;
+        this._textTrackStyle = player?.textTrackStyle;
         this._updateFromPlayer();
-        if (this._player !== undefined) {
-            this._player.textTrackStyle.addEventListener('change', this._updateFromPlayer);
-        }
+        this._textTrackStyle?.addEventListener('change', this._updateFromPlayer);
     }
 
     private readonly _updateFromPlayer = (): void => {

--- a/src/components/TextTrackStyleRadioGroup.ts
+++ b/src/components/TextTrackStyleRadioGroup.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { RadioGroup } from './RadioGroup';
 import verticalRadioGroupCss from './VerticalRadioGroup.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer, EdgeStyle } from 'theoplayer/chromeless';
+import type { ChromelessPlayer, EdgeStyle, TextTrackStyle } from 'theoplayer/chromeless';
 import type { RadioButton } from './RadioButton';
 import { createEvent } from '../util/EventUtils';
 import { Attribute } from '../util/Attribute';
@@ -45,6 +45,7 @@ export class TextTrackStyleRadioGroup extends StateReceiverMixin(HTMLElement, ['
     private readonly _radioGroup: RadioGroup;
     private readonly _optionsSlot: HTMLSlotElement;
     private _player: ChromelessPlayer | undefined;
+    private _textTrackStyle: TextTrackStyle | undefined;
     private _value: any;
 
     constructor() {
@@ -125,14 +126,11 @@ export class TextTrackStyleRadioGroup extends StateReceiverMixin(HTMLElement, ['
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.textTrackStyle.removeEventListener('change', this._updateFromPlayer);
-        }
+        this._textTrackStyle?.removeEventListener('change', this._updateFromPlayer);
         this._player = player;
+        this._textTrackStyle = player?.textTrackStyle;
         this._updateFromPlayer();
-        if (this._player !== undefined) {
-            this._player.textTrackStyle.addEventListener('change', this._updateFromPlayer);
-        }
+        this._textTrackStyle?.addEventListener('change', this._updateFromPlayer);
     }
 
     private readonly _updateChecked = (): void => {

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -3,7 +3,7 @@ import { Range, rangeTemplate } from './Range';
 import timeRangeHtml from './TimeRange.html';
 import timeRangeCss from './TimeRange.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/chromeless';
+import type { Ads, ChromelessPlayer } from 'theoplayer/chromeless';
 import { formatAsTimePhrase } from '../util/TimeUtils';
 import { createCustomEvent } from '../util/EventUtils';
 import type { PreviewTimeChangeEvent } from '../events/PreviewTimeChangeEvent';
@@ -49,6 +49,7 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
     private readonly _previewBoxEl: HTMLElement;
 
     private _player: ChromelessPlayer | undefined;
+    private _ads: Ads | undefined;
     private _pausedWhileScrubbing: boolean = false;
 
     private _autoAdvanceId: number = 0;
@@ -90,16 +91,17 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
         if (this._player !== undefined) {
             this._player.removeEventListener(UPDATE_EVENTS, this._updateFromPlayer);
             this._player.removeEventListener(AUTO_ADVANCE_EVENTS, this._toggleAutoAdvance);
-            this._player.ads?.removeEventListener(AD_EVENTS, this._onAdChange);
         }
+        this._ads?.removeEventListener(AD_EVENTS, this._onAdChange);
         this._player = player;
+        this._ads = player?.ads;
         this._updateFromPlayer();
         this._toggleAutoAdvance();
         if (this._player !== undefined) {
             this._player.addEventListener(UPDATE_EVENTS, this._updateFromPlayer);
             this._player.addEventListener(AUTO_ADVANCE_EVENTS, this._toggleAutoAdvance);
-            this._player.ads?.addEventListener(AD_EVENTS, this._onAdChange);
         }
+        this._ads?.addEventListener(AD_EVENTS, this._onAdChange);
     }
 
     get streamType(): StreamType {

--- a/src/components/ads/AdClickThroughButton.ts
+++ b/src/components/ads/AdClickThroughButton.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import { LinkButton, linkButtonTemplate } from '../LinkButton';
 import { StateReceiverMixin } from '../StateReceiverMixin';
 import { Attribute } from '../../util/Attribute';
-import type { ChromelessPlayer } from 'theoplayer/chromeless';
+import type { Ads, ChromelessPlayer } from 'theoplayer/chromeless';
 import { arrayFind } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 import { createTemplate } from '../../util/TemplateUtils';
@@ -18,6 +18,7 @@ const AD_EVENTS = ['adbegin', 'adend', 'adloaded', 'updatead', 'adskip'] as cons
  */
 export class AdClickThroughButton extends StateReceiverMixin(LinkButton, ['player']) {
     private _player: ChromelessPlayer | undefined;
+    private _ads: Ads | undefined;
 
     static get observedAttributes() {
         return [...LinkButton.observedAttributes, Attribute.CLICKTHROUGH];
@@ -58,14 +59,11 @@ export class AdClickThroughButton extends StateReceiverMixin(LinkButton, ['playe
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.ads?.removeEventListener(AD_EVENTS, this._updateFromPlayer);
-        }
+        this._ads?.removeEventListener(AD_EVENTS, this._updateFromPlayer);
         this._player = player;
+        this._ads = player?.ads;
         this._updateFromPlayer();
-        if (this._player !== undefined) {
-            this._player.ads?.addEventListener(AD_EVENTS, this._updateFromPlayer);
-        }
+        this._ads?.addEventListener(AD_EVENTS, this._updateFromPlayer);
     }
 
     attributeChangedCallback(attrName: string, oldValue: any, newValue: any) {

--- a/src/components/ads/AdCountdown.ts
+++ b/src/components/ads/AdCountdown.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from '../TextDisplay.css';
 import adCountdownCss from './AdCountdown.css';
 import { StateReceiverMixin } from '../StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/chromeless';
+import type { Ads, ChromelessPlayer } from 'theoplayer/chromeless';
 import { setTextContent } from '../../util/CommonUtils';
 import { createTemplate } from '../../util/TemplateUtils';
 
@@ -18,6 +18,7 @@ const AD_EVENTS = ['adbreakbegin', 'adbreakend', 'adbreakchange', 'updateadbreak
 export class AdCountdown extends StateReceiverMixin(HTMLElement, ['player']) {
     private readonly _spanEl: HTMLElement;
     private _player: ChromelessPlayer | undefined;
+    private _ads: Ads | undefined;
 
     constructor() {
         super();
@@ -49,15 +50,12 @@ export class AdCountdown extends StateReceiverMixin(HTMLElement, ['player']) {
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.removeEventListener('timeupdate', this._update);
-            this._player.ads?.removeEventListener(AD_EVENTS, this._onAdChange);
-        }
+        this._player?.removeEventListener('timeupdate', this._update);
+        this._ads?.removeEventListener(AD_EVENTS, this._onAdChange);
         this._player = player;
+        this._ads = player?.ads;
         this._onAdChange();
-        if (this._player !== undefined) {
-            this._player.ads?.addEventListener(AD_EVENTS, this._onAdChange);
-        }
+        this._ads?.addEventListener(AD_EVENTS, this._onAdChange);
     }
 
     private readonly _onAdChange = () => {

--- a/src/components/ads/AdDisplay.ts
+++ b/src/components/ads/AdDisplay.ts
@@ -2,7 +2,7 @@ import * as shadyCss from '@webcomponents/shadycss';
 import textDisplayCss from '../TextDisplay.css';
 import adDisplayCss from './AdDisplay.css';
 import { StateReceiverMixin } from '../StateReceiverMixin';
-import type { ChromelessPlayer } from 'theoplayer/chromeless';
+import type { Ads, ChromelessPlayer } from 'theoplayer/chromeless';
 import { arrayFind, setTextContent } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 import { createTemplate } from '../../util/TemplateUtils';
@@ -20,6 +20,7 @@ const AD_EVENTS = ['adbreakbegin', 'adbreakend', 'adbreakchange', 'updateadbreak
 export class AdDisplay extends StateReceiverMixin(HTMLElement, ['player']) {
     private readonly _spanEl: HTMLElement;
     private _player: ChromelessPlayer | undefined;
+    private _ads: Ads | undefined;
 
     constructor() {
         super();
@@ -51,14 +52,11 @@ export class AdDisplay extends StateReceiverMixin(HTMLElement, ['player']) {
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.ads?.removeEventListener(AD_EVENTS, this._updateFromPlayer);
-        }
+        this._ads?.removeEventListener(AD_EVENTS, this._updateFromPlayer);
         this._player = player;
+        this._ads = player?.ads;
         this._updateFromPlayer();
-        if (this._player !== undefined) {
-            this._player.ads?.addEventListener(AD_EVENTS, this._updateFromPlayer);
-        }
+        this._ads?.addEventListener(AD_EVENTS, this._updateFromPlayer);
     }
 
     private readonly _updateFromPlayer = () => {

--- a/src/components/ads/AdSkipButton.ts
+++ b/src/components/ads/AdSkipButton.ts
@@ -4,7 +4,7 @@ import adSkipButtonCss from './AdSkipButton.css';
 import skipNextIcon from '../../icons/skip-next.svg';
 import { StateReceiverMixin } from '../StateReceiverMixin';
 import { Attribute } from '../../util/Attribute';
-import type { ChromelessPlayer } from 'theoplayer/chromeless';
+import type { Ads, ChromelessPlayer } from 'theoplayer/chromeless';
 import { arrayFind, setTextContent } from '../../util/CommonUtils';
 import { isLinearAd } from '../../util/AdUtils';
 import { createTemplate } from '../../util/TemplateUtils';
@@ -33,6 +33,7 @@ export class AdSkipButton extends StateReceiverMixin(Button, ['player']) {
     private readonly _countdownEl: HTMLElement;
     private readonly _skipEl: HTMLElement;
     private _player: ChromelessPlayer | undefined;
+    private _ads: Ads | undefined;
 
     static get observedAttributes() {
         return [...Button.observedAttributes];
@@ -59,15 +60,12 @@ export class AdSkipButton extends StateReceiverMixin(Button, ['player']) {
         if (this._player === player) {
             return;
         }
-        if (this._player !== undefined) {
-            this._player.removeEventListener('timeupdate', this._update);
-            this._player.ads?.removeEventListener(AD_EVENTS, this._onAdChange);
-        }
+        this._player?.removeEventListener('timeupdate', this._update);
+        this._ads?.removeEventListener(AD_EVENTS, this._onAdChange);
         this._player = player;
+        this._ads = player?.ads;
         this._onAdChange();
-        if (this._player !== undefined) {
-            this._player.ads?.addEventListener(AD_EVENTS, this._onAdChange);
-        }
+        this._ads?.addEventListener(AD_EVENTS, this._onAdChange);
     }
 
     protected override handleClick(): void {

--- a/src/components/theolive/quality/AbstractQualitySelector.ts
+++ b/src/components/theolive/quality/AbstractQualitySelector.ts
@@ -1,4 +1,4 @@
-import type { ChromelessPlayer } from 'theoplayer/chromeless';
+import type { ChromelessPlayer, TheoLiveApi } from 'theoplayer/chromeless';
 import { type ButtonOptions } from '../../Button';
 import { StateReceiverMixin } from '../../StateReceiverMixin';
 import { RadioButton } from '../../RadioButton';
@@ -12,6 +12,7 @@ import { Attribute } from '../../../util/Attribute';
  */
 export abstract class AbstractQualitySelector extends StateReceiverMixin(RadioButton, ['player']) {
     private _player: ChromelessPlayer | undefined;
+    private _theoLive: TheoLiveApi | undefined;
     protected _slotEl: HTMLSlotElement;
     protected _badNetworkMode: boolean = false;
 
@@ -28,16 +29,16 @@ export abstract class AbstractQualitySelector extends StateReceiverMixin(RadioBu
         if (this._player === player) {
             return;
         }
-        if (this._player) {
-            this._player.theoLive?.removeEventListener('enterbadnetworkmode', this.handleEnterBadNetworkMode_);
-            this._player.theoLive?.removeEventListener('exitbadnetworkmode', this.handleExitBadNetworkMode_);
+        if (this._theoLive) {
+            this._theoLive.removeEventListener('enterbadnetworkmode', this.handleEnterBadNetworkMode_);
+            this._theoLive.removeEventListener('exitbadnetworkmode', this.handleExitBadNetworkMode_);
         }
         this._player = player;
-        this._badNetworkMode = false;
-        if (this._player) {
-            this._badNetworkMode = this._player.theoLive?.badNetworkMode ?? false;
-            this._player.theoLive?.addEventListener('enterbadnetworkmode', this.handleEnterBadNetworkMode_);
-            this._player.theoLive?.addEventListener('exitbadnetworkmode', this.handleExitBadNetworkMode_);
+        this._theoLive = player?.theoLive;
+        this._badNetworkMode = this._theoLive?.badNetworkMode ?? false;
+        if (this._theoLive) {
+            this._theoLive.addEventListener('enterbadnetworkmode', this.handleEnterBadNetworkMode_);
+            this._theoLive.addEventListener('exitbadnetworkmode', this.handleExitBadNetworkMode_);
         }
         this.handlePlayer();
     }

--- a/src/components/theolive/quality/BadNetworkModeButton.ts
+++ b/src/components/theolive/quality/BadNetworkModeButton.ts
@@ -1,4 +1,4 @@
-import { ChromelessPlayer as TheoPlayer } from 'theoplayer/chromeless';
+import { ChromelessPlayer as TheoPlayer, type TheoLiveApi } from 'theoplayer/chromeless';
 import settingsCss from './BadNetworkModeButton.css';
 import { buttonTemplate } from '../../Button';
 import settingsIcon from '../../../icons/settings.svg';
@@ -19,6 +19,7 @@ const template = createTemplate('theolive-bad-network-button', buttonTemplate(ht
  */
 export class BadNetworkModeButton extends StateReceiverMixin(MenuButton, ['player']) {
     private _player: TheoPlayer | undefined;
+    private _theoLive: TheoLiveApi | undefined;
     private _warningIcon: HTMLElement | undefined;
 
     constructor() {
@@ -55,14 +56,15 @@ export class BadNetworkModeButton extends StateReceiverMixin(MenuButton, ['playe
         if (this._player === player) {
             return;
         }
-        if (this._player) {
-            this._player.theoLive?.removeEventListener('enterbadnetworkmode', this.handleEnterBadNetworkMode_);
-            this._player.theoLive?.removeEventListener('exitbadnetworkmode', this.handleExitBadNetworkMode_);
+        if (this._theoLive) {
+            this._theoLive.removeEventListener('enterbadnetworkmode', this.handleEnterBadNetworkMode_);
+            this._theoLive.removeEventListener('exitbadnetworkmode', this.handleExitBadNetworkMode_);
         }
         this._player = player;
-        if (this._player) {
-            this._player.theoLive?.addEventListener('enterbadnetworkmode', this.handleEnterBadNetworkMode_);
-            this._player.theoLive?.addEventListener('exitbadnetworkmode', this.handleExitBadNetworkMode_);
+        this._theoLive = player?.theoLive;
+        if (this._theoLive) {
+            this._theoLive.addEventListener('enterbadnetworkmode', this.handleEnterBadNetworkMode_);
+            this._theoLive.addEventListener('exitbadnetworkmode', this.handleExitBadNetworkMode_);
         }
     }
 }


### PR DESCRIPTION
Web UI wasn't correctly removing all its event listeners when THEOplayer is destroyed through `ui.player.destroy()` (where `ui` is a `<theoplayer-default-ui>` or `<theoplayer-ui>`). This caused a whole bunch of errors when those event listeners fire while the player is being destroyed.

React UI now calls `player.destroy()` during unmount, if for some reason that didn't happen yet. (Normally, this happens automatically when the custom element is disconnected from the DOM.)

Fixes #59