### PR TITLE
Add source selection to all examples

### DIFF
--- a/docs/components/Example.tsx
+++ b/docs/components/Example.tsx
@@ -9,7 +9,7 @@ export interface Props extends ComponentPropsWithoutRef<'iframe'> {
 export default function Example({ hideSource, hideDeviceType, ...props }: Props): JSX.Element {
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
 
-    const [sourceName, setSourceName] = useState<SourceName>('hls');
+    const [sourceName, setSourceName] = useState<SourceName>('bigBuckBunny');
     const [deviceType, setDeviceType] = useState('');
 
     // Send message to <iframe> when source changes

--- a/docs/components/Example.tsx
+++ b/docs/components/Example.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentPropsWithoutRef, forwardRef, type JSX, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { type ComponentPropsWithoutRef, type JSX, useEffect, useRef, useState } from 'react';
 import { type SourceName, sources } from './sources';
 
 export interface Props extends ComponentPropsWithoutRef<'iframe'> {
@@ -6,9 +6,8 @@ export interface Props extends ComponentPropsWithoutRef<'iframe'> {
     hideDeviceType?: boolean;
 }
 
-export default forwardRef<HTMLIFrameElement | null, Props>(function Example({ hideSource, hideDeviceType, ...props }: Props, ref): JSX.Element {
+export default function Example({ hideSource, hideDeviceType, ...props }: Props): JSX.Element {
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
-    useImperativeHandle(ref, () => iframeRef.current, [iframeRef.current]);
 
     const [sourceName, setSourceName] = useState<SourceName>('hls');
     const [deviceType, setDeviceType] = useState('');
@@ -66,4 +65,4 @@ export default forwardRef<HTMLIFrameElement | null, Props>(function Example({ hi
             )}
         </>
     );
-});
+}

--- a/docs/components/Example.tsx
+++ b/docs/components/Example.tsx
@@ -36,7 +36,7 @@ export default function Example({ hideSource, hideDeviceType, ...props }: Props)
                 <p>
                     {!hideSource && (
                         <div>
-                            <label>
+                            <label style={{ userSelect: 'none' }}>
                                 Source:{' '}
                                 <select value={sourceName} onChange={(ev) => setSourceName(ev.target.value as SourceName)}>
                                     {Object.entries(sources).map(([key, value]) => (

--- a/docs/components/sources.ts
+++ b/docs/components/sources.ts
@@ -1,0 +1,43 @@
+interface TypedSource {
+    src: string;
+    type?: string;
+}
+
+interface TextTrackDescription {
+    src: string;
+    srclang?: string;
+    kind?: string;
+    format?: string;
+    label?: string;
+    id?: string;
+    default?: boolean;
+}
+
+interface SourceDescription {
+    sources: TypedSource | TypedSource[];
+    metadata: {
+        title: string;
+    };
+    textTracks?: TextTrackDescription[];
+}
+
+export const sources = {
+    hls: {
+        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+        metadata: { title: 'Big Buck Bunny' },
+        textTracks: [
+            {
+                default: true,
+                src: 'https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt',
+                label: 'thumbnails',
+                kind: 'metadata'
+            }
+        ]
+    },
+    dash: {
+        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+        metadata: { title: 'Big Buck Bunny' }
+    }
+} as const satisfies Record<string, SourceDescription>;
+
+export type SourceName = keyof typeof sources;

--- a/docs/components/sources.ts
+++ b/docs/components/sources.ts
@@ -18,11 +18,12 @@ interface SourceDescription {
     metadata: {
         title: string;
     };
+    poster?: string;
     textTracks?: TextTrackDescription[];
 }
 
 export const sources = {
-    hls: {
+    bigBuckBunny: {
         sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
         metadata: { title: 'Big Buck Bunny' },
         textTracks: [
@@ -34,9 +35,26 @@ export const sources = {
             }
         ]
     },
-    dash: {
-        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
-        metadata: { title: 'Big Buck Bunny' }
+    elephantsDream: {
+        sources: { src: 'https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8' },
+        metadata: { title: "Elephant's Dream" },
+        textTracks: [
+            {
+                default: true,
+                src: 'https://cdn.theoplayer.com/video/elephants-dream/thumbnails.vtt',
+                label: 'thumbnails',
+                kind: 'metadata'
+            }
+        ]
+    },
+    starWarsTrailer: {
+        sources: {
+            src: 'https://cdn.theoplayer.com/video/star_wars_episode_vii-the_force_awakens_official_comic-con_2015_reel_(2015)/index.m3u8'
+        },
+        metadata: {
+            title: 'Star Wars Episode VII Trailer'
+        },
+        poster: 'https://cdn.theoplayer.com/video/star_wars_episode_vii-the_force_awakens_official_comic-con_2015_reel_(2015)/poster.jpg'
     }
 } as const satisfies Record<string, SourceDescription>;
 

--- a/docs/react/components/ReactExample.tsx
+++ b/docs/react/components/ReactExample.tsx
@@ -1,30 +1,12 @@
 import React, { type JSX, useEffect, useState } from 'react';
 import Example, { type Props as ExampleProps } from '../../components/Example';
-
-const sources = {
-    hls: {
-        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
-        metadata: { title: 'Big Buck Bunny' },
-        textTracks: [
-            {
-                default: true,
-                src: 'https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt',
-                label: 'thumbnails',
-                kind: 'metadata'
-            }
-        ]
-    },
-    dash: {
-        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
-        metadata: { title: 'Big Buck Bunny' }
-    }
-};
+import { type SourceName, sources } from '../../components/sources';
 
 export interface Props extends ExampleProps {}
 
 export default function ReactExample(props: Props): JSX.Element {
     const [iframe, setIframe] = useState<HTMLIFrameElement | null>(null);
-    const [sourceName, setSourceName] = useState('hls');
+    const [sourceName, setSourceName] = useState<SourceName>('hls');
 
     // Send message to <iframe> when source changes
     useEffect(() => {
@@ -42,7 +24,7 @@ export default function ReactExample(props: Props): JSX.Element {
                 <div>
                     <label>
                         Source:{' '}
-                        <select value={sourceName} onChange={(ev) => setSourceName(ev.target.value)}>
+                        <select value={sourceName} onChange={(ev) => setSourceName(ev.target.value as SourceName)}>
                             {Object.entries(sources).map(([key, value]) => (
                                 <option key={key} value={key}>
                                     {value.metadata.title}

--- a/docs/react/components/ReactExample.tsx
+++ b/docs/react/components/ReactExample.tsx
@@ -1,8 +1,0 @@
-import React, { type JSX } from 'react';
-import Example, { type Props as ExampleProps } from '../../components/Example';
-
-export interface Props extends ExampleProps {}
-
-export default function ReactExample(props: Props): JSX.Element {
-    return <Example {...props} />;
-}

--- a/docs/react/components/ReactExample.tsx
+++ b/docs/react/components/ReactExample.tsx
@@ -1,39 +1,8 @@
-import React, { type JSX, useEffect, useState } from 'react';
+import React, { type JSX } from 'react';
 import Example, { type Props as ExampleProps } from '../../components/Example';
-import { type SourceName, sources } from '../../components/sources';
 
 export interface Props extends ExampleProps {}
 
 export default function ReactExample(props: Props): JSX.Element {
-    const [iframe, setIframe] = useState<HTMLIFrameElement | null>(null);
-    const [sourceName, setSourceName] = useState<SourceName>('hls');
-
-    // Send message to <iframe> when source changes
-    useEffect(() => {
-        iframe?.contentWindow?.postMessage({
-            type: 'source',
-            source: sources[sourceName]
-        });
-    }, [iframe, sourceName]);
-
-    return (
-        <Example
-            ref={setIframe}
-            {...props}
-            options={
-                <div>
-                    <label>
-                        Source:{' '}
-                        <select value={sourceName} onChange={(ev) => setSourceName(ev.target.value as SourceName)}>
-                            {Object.entries(sources).map(([key, value]) => (
-                                <option key={key} value={key}>
-                                    {value.metadata.title}
-                                </option>
-                            ))}
-                        </select>
-                    </label>
-                </div>
-            }
-        />
-    );
+    return <Example {...props} />;
 }

--- a/docs/react/examples/custom-ui.mdx
+++ b/docs/react/examples/custom-ui.mdx
@@ -6,11 +6,11 @@ slug: /react/examples/custom-ui
 
 # Custom UI
 
-import ReactExample from '../components/ReactExample';
+import Example from '../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './shared.module.css';
 
-<ReactExample className={styles.player} src={useBaseUrl('/open-video-ui/v1/examples/react/custom-ui/demo.html')} hideDeviceType />
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v1/examples/react/custom-ui/demo.html')} hideDeviceType />
 
 <details>
     <summary>Code</summary>

--- a/docs/react/examples/default-ui.mdx
+++ b/docs/react/examples/default-ui.mdx
@@ -6,11 +6,11 @@ slug: /react/examples/default-ui
 
 # Default UI
 
-import ReactExample from '../components/ReactExample';
+import Example from '../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './shared.module.css';
 
-<ReactExample className={styles.player} src={useBaseUrl('/open-video-ui/v1/examples/react/default-ui/demo.html')} />
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v1/examples/react/default-ui/demo.html')} />
 
 <details>
     <summary>Code</summary>

--- a/docs/static/open-video-ui/v1/examples/web/custom-ui/demo.html
+++ b/docs/static/open-video-ui/v1/examples/web/custom-ui/demo.html
@@ -24,7 +24,7 @@
         -->
         <theoplayer-ui
             configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
-            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
         >
             <theoplayer-control-bar slot="top-chrome" class="top-chrome">
                 <span class="title">Big Buck Bunny</span>

--- a/docs/static/open-video-ui/v1/examples/web/default-ui/demo.html
+++ b/docs/static/open-video-ui/v1/examples/web/default-ui/demo.html
@@ -42,7 +42,7 @@
         -->
         <theoplayer-default-ui
             configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
-            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
         ></theoplayer-default-ui>
     </body>
 </html>

--- a/docs/static/open-video-ui/v1/examples/web/nitflex/demo.html
+++ b/docs/static/open-video-ui/v1/examples/web/nitflex/demo.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />

--- a/docs/static/open-video-ui/v1/examples/web/nitflex/demo.html
+++ b/docs/static/open-video-ui/v1/examples/web/nitflex/demo.html
@@ -34,7 +34,7 @@
         -->
         <theoplayer-ui
             configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
-            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/dash/theoplayer/thumbnails/big_buck_bunny_thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
             fluid
         >
             <theoplayer-control-bar slot="top-chrome" class="top-chrome">

--- a/docs/static/open-video-ui/v1/examples/web/nitflex/demo.html
+++ b/docs/static/open-video-ui/v1/examples/web/nitflex/demo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
@@ -34,7 +34,7 @@
         -->
         <theoplayer-ui
             configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
-            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/dash/theoplayer/thumbnails/big_buck_bunny_thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/dash/theoplayer/thumbnails/big_buck_bunny_thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
             fluid
         >
             <theoplayer-control-bar slot="top-chrome" class="top-chrome">
@@ -75,5 +75,24 @@
             </theoplayer-language-menu>
             <theoplayer-error-display slot="error"></theoplayer-error-display>
         </theoplayer-ui>
+        <script>
+            var ui = document.querySelector('theoplayer-ui');
+            var titleEl = ui.querySelector('.title');
+            if (ui.player) {
+                onPlayerReady();
+            } else {
+                ui.addEventListener('theoplayerready', onPlayerReady, { once: true });
+            }
+
+            function onPlayerReady() {
+                ui.player.addEventListener('sourcechange', updateTitle);
+                updateTitle();
+            }
+
+            function updateTitle() {
+                var source = ui.player.source;
+                titleEl.textContent = (source && source.metadata && source.metadata.title) || '';
+            }
+        </script>
     </body>
 </html>

--- a/docs/static/open-video-ui/v1/examples/web/styling/demo.html
+++ b/docs/static/open-video-ui/v1/examples/web/styling/demo.html
@@ -68,7 +68,7 @@
         -->
         <theoplayer-default-ui
             configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
-            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
         ></theoplayer-default-ui>
     </body>
 </html>

--- a/docs/static/open-video-ui/v1/examples/web/utils.js
+++ b/docs/static/open-video-ui/v1/examples/web/utils.js
@@ -8,6 +8,8 @@
  * Supported message formats for `event.data`:
  * - `{ type: "deviceType", deviceType: "" | "desktop" | "mobile" | "tv" }`
  *   Overrides the player's device type.
+ * - `{ type: "source", source: SourceDescription }`
+ *   Changes the player's source.
  * - `{ type: "style", style: string }`
  *   Updates the custom CSS style.
  */
@@ -19,6 +21,13 @@ window.addEventListener('message', (event) => {
         case 'deviceType': {
             const ui = document.querySelector('theoplayer-default-ui, theoplayer-ui');
             ui?.setAttribute('device-type', data.deviceType);
+            break;
+        }
+        case 'source': {
+            const ui = document.querySelector('theoplayer-default-ui, theoplayer-ui');
+            if (ui) {
+                ui.source = data.source;
+            }
             break;
         }
         case 'style': {


### PR DESCRIPTION
Currently, only the React examples have a "Source" dropdown to select the player's source. This PR adds it to both Web and React examples.

The default source is still Big Buck Bunny (see #67). I've added Elephant's Dream and the Star Wars trailer as alternative sources, so we can showcase our subtitle and alternative audio support.