### PR TITLE
Optimize auto-advance logic in `TimeRange`

### DIFF
--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -245,17 +245,15 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
         }
     }
 
-    protected isVisibleValueChange_(newValue: number): boolean {
-        const { value, min, max } = this;
+    protected getMinimumStepForVisibleChange_(): number {
+        // The smallest visible change is 1 pixel.
+        // Compute how much the value needs to change for that.
+        const { min, max } = this;
         const relativeMax = max - min;
-        if (isNaN(relativeMax) || relativeMax <= 0) {
-            return false;
+        if (relativeMax <= 0) {
+            return NaN;
         }
-        // Compute the pixel offsets for the old and new values
-        const oldOffset = ((value - min) / relativeMax) * this._rangeWidth;
-        const newOffset = ((newValue - min) / relativeMax) * this._rangeWidth;
-        // The offsets must differ by at least one pixel to be visible
-        return Math.abs(newOffset - oldOffset) >= 1;
+        return relativeMax / this._rangeWidth;
     }
 
     private readonly _updatePointerBar = (e: PointerEvent): void => {

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -176,8 +176,11 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
         if (this.hasAttribute(Attribute.HIDDEN)) {
             return;
         }
+        if (!useCachedWidth) {
+            this.updateCachedWidths_();
+        }
         this._rangeEl.setAttribute('aria-valuetext', this.getAriaValueText());
-        this.updateBar_(useCachedWidth);
+        this.updateBar_();
     }
 
     /**
@@ -196,8 +199,8 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
      * showing playback progress or volume level. Here we're building that bar
      * by using a background gradient that moves with the range value.
      */
-    private updateBar_(useCachedWidth?: boolean) {
-        const gradientStops = this.getBarColors(useCachedWidth).toGradientStops();
+    private updateBar_() {
+        const gradientStops = this.getBarColors().toGradientStops();
         shadyCss.styleSubtree(this, {
             '--theoplayer-range-track-progress-internal': `linear-gradient(to right, ${gradientStops})`
         });
@@ -207,17 +210,13 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
      * Build the color gradient for the range bar.
      * Creating an array so progress-bar can insert the buffered bar.
      */
-    protected getBarColors(useCachedWidth?: boolean): ColorStops {
+    protected getBarColors(): ColorStops {
         const { value, min, max } = this;
         const relativeValue = value - min;
         const relativeMax = max - min;
         let rangePercent = (relativeValue / relativeMax) * 100;
         if (isNaN(rangePercent)) {
             rangePercent = 0;
-        }
-
-        if (!useCachedWidth) {
-            this.updateCachedWidths_();
         }
 
         let thumbPercent = 0;

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -208,8 +208,9 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
      * Creating an array so progress-bar can insert the buffered bar.
      */
     protected getBarColors(useCachedWidth?: boolean): ColorStops {
-        const relativeValue = this.value - this.min;
-        const relativeMax = this.max - this.min;
+        const { value, min, max } = this;
+        const relativeValue = value - min;
+        const relativeMax = max - min;
         let rangePercent = (relativeValue / relativeMax) * 100;
         if (isNaN(rangePercent)) {
             rangePercent = 0;
@@ -223,7 +224,7 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
         // If the range thumb is at min or max don't correct the time range.
         // Ideally the thumb center would go all the way to min and max values
         // but input[type=range] doesn't play like that.
-        if (this.min < this.value && this.value < this.max) {
+        if (min < value && value < max) {
             const thumbOffset = this._thumbWidth * (0.5 - rangePercent / 100);
             thumbPercent = (thumbOffset / this._rangeWidth) * 100;
         }

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -246,6 +246,19 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
         }
     }
 
+    protected isVisibleValueChange_(newValue: number): boolean {
+        const { value, min, max } = this;
+        const relativeMax = max - min;
+        if (isNaN(relativeMax) || relativeMax <= 0) {
+            return false;
+        }
+        // Compute the pixel offsets for the old and new values
+        const oldOffset = ((value - min) / relativeMax) * this._rangeWidth;
+        const newOffset = ((newValue - min) / relativeMax) * this._rangeWidth;
+        // The offsets must differ by at least one pixel to be visible
+        return Math.abs(newOffset - oldOffset) >= 1;
+    }
+
     private readonly _updatePointerBar = (e: PointerEvent): void => {
         if (this.disabled) {
             return;

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -30,7 +30,8 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
 
     protected readonly _rangeEl: HTMLInputElement;
     protected readonly _pointerEl: HTMLElement;
-    private _lastRangeWidth: number = 0;
+    private _rangeWidth: number = 0;
+    private _thumbWidth: number = 10;
 
     constructor(options: RangeOptions) {
         super();
@@ -215,7 +216,7 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
         }
 
         if (!useCachedWidth) {
-            this.updateRangeWidth_();
+            this.updateCachedWidths_();
         }
 
         let thumbPercent = 0;
@@ -223,9 +224,8 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
         // Ideally the thumb center would go all the way to min and max values
         // but input[type=range] doesn't play like that.
         if (this.min < this.value && this.value < this.max) {
-            const thumbWidth = getComputedStyle(this).getPropertyValue('--theoplayer-range-thumb-width') || '10px';
-            const thumbOffset = parseInt(thumbWidth) * (0.5 - rangePercent / 100);
-            thumbPercent = (thumbOffset / this._lastRangeWidth) * 100;
+            const thumbOffset = this._thumbWidth * (0.5 - rangePercent / 100);
+            thumbPercent = (thumbOffset / this._rangeWidth) * 100;
         }
 
         const stops = new ColorStops();
@@ -233,11 +233,15 @@ export abstract class Range extends StateReceiverMixin(HTMLElement, ['deviceType
         return stops;
     }
 
-    private updateRangeWidth_(): void {
+    private updateCachedWidths_(): void {
         // Use the last non-zero range width, in case the range is temporarily hidden.
         const rangeWidth = this._rangeEl.offsetWidth;
         if (rangeWidth > 0) {
-            this._lastRangeWidth = rangeWidth;
+            this._rangeWidth = rangeWidth;
+        }
+        const thumbWidth = parseInt(getComputedStyle(this).getPropertyValue('--theoplayer-range-thumb-width') || '10px');
+        if (thumbWidth > 0) {
+            this._thumbWidth = thumbWidth;
         }
     }
 

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -3,7 +3,7 @@ import { Range, rangeTemplate } from './Range';
 import timeRangeHtml from './TimeRange.html';
 import timeRangeCss from './TimeRange.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
-import type { Ads, ChromelessPlayer } from 'theoplayer/chromeless';
+import type { Ads, ChromelessPlayer, TimeRanges } from 'theoplayer/chromeless';
 import { formatAsTimePhrase } from '../util/TimeUtils';
 import { createCustomEvent } from '../util/EventUtils';
 import type { PreviewTimeChangeEvent } from '../events/PreviewTimeChangeEvent';
@@ -137,18 +137,18 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
         this._rangeEl.max = String(max);
         this._rangeEl.valueAsNumber = this._lastCurrentTime;
         this.update();
-        this._updateDisabled();
+        this.updateDisabled_(seekable);
     };
 
-    private readonly _updateDisabled = () => {
+    private updateDisabled_(seekable: TimeRanges | undefined = this._player?.seekable) {
         let disabled = this.streamType === 'live';
-        if (this._player !== undefined) {
-            disabled ||= this._player.seekable.length === 0;
+        if (seekable !== undefined) {
+            disabled ||= seekable.length === 0;
         }
         if (this.disabled !== disabled) {
             this.disabled = disabled;
         }
-    };
+    }
 
     protected override getAriaLabel(): string {
         return 'seek';
@@ -169,7 +169,7 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
             return;
         }
         if (attrName === Attribute.STREAM_TYPE) {
-            this._updateDisabled();
+            this.updateDisabled_();
         } else if (attrName === Attribute.SHOW_AD_MARKERS) {
             this.update();
         }

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -245,10 +245,13 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
         }
 
         const delta = (performance.now() - this._lastUpdateTime) / 1000;
-        this._rangeEl.valueAsNumber = this._lastCurrentTime + delta * this._lastPlaybackRate;
+        const newValue = this._lastCurrentTime + delta * this._lastPlaybackRate;
+        if (this.isVisibleValueChange_(newValue)) {
+            this._rangeEl.valueAsNumber = newValue;
 
-        // Use cached width to avoid synchronous layout
-        this.update(/* useCachedWidth = */ true);
+            // Use cached width to avoid synchronous layout
+            this.update(/* useCachedWidth = */ true);
+        }
 
         this._autoAdvanceId = requestAnimationFrame(this._autoAdvanceWhilePlaying);
     };

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -242,7 +242,9 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
 
         const delta = (performance.now() - this._lastUpdateTime) / 1000;
         this._rangeEl.valueAsNumber = this._lastCurrentTime + delta * this._lastPlaybackRate;
-        this.update();
+
+        // Use cached width to avoid synchronous layout
+        this.update(/* useCachedWidth = */ true);
 
         this._autoAdvanceId = requestAnimationFrame(this._autoAdvanceWhilePlaying);
     };
@@ -273,8 +275,8 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
         this.dispatchEvent(previewTimeChangeEvent);
     }
 
-    protected override getBarColors(): ColorStops {
-        const colorStops = super.getBarColors();
+    protected override getBarColors(useCachedWidth?: boolean): ColorStops {
+        const colorStops = super.getBarColors(useCachedWidth);
         if (!this.hasAttribute(Attribute.SHOW_AD_MARKERS) || !this._player || !this._player.ads) {
             return colorStops;
         }

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -282,8 +282,8 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
         this.dispatchEvent(previewTimeChangeEvent);
     }
 
-    protected override getBarColors(useCachedWidth?: boolean): ColorStops {
-        const colorStops = super.getBarColors(useCachedWidth);
+    protected override getBarColors(): ColorStops {
+        const colorStops = super.getBarColors();
         if (!this.hasAttribute(Attribute.SHOW_AD_MARKERS) || !this._player || !this._player.ads) {
             return colorStops;
         }

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -120,17 +120,21 @@ export class TimeRange extends StateReceiverMixin(Range, ['player', 'streamType'
         this._lastCurrentTime = this._player.currentTime;
         this._lastPlaybackRate = this._player.playbackRate;
         const seekable = this._player.seekable;
+        let min: number;
+        let max: number;
         if (seekable.length !== 0) {
-            this.min = seekable.start(0);
-            this.max = seekable.end(0);
+            min = seekable.start(0);
+            max = seekable.end(0);
         } else {
-            this.min = 0;
-            this.max = this._player.duration;
+            min = 0;
+            max = this._player.duration;
         }
         if (!isFinite(this._lastCurrentTime)) {
             const isLive = this._player.duration === Infinity;
-            this._lastCurrentTime = isLive ? this.max : this.min;
+            this._lastCurrentTime = isLive ? max : min;
         }
+        this._rangeEl.min = String(min);
+        this._rangeEl.max = String(max);
         this._rangeEl.valueAsNumber = this._lastCurrentTime;
         this.update();
         this._updateDisabled();


### PR DESCRIPTION
Currently, the auto-advance logic in `<theoplayer-time-range>` runs very frequently (every animation frame), even in case where it's not really needed. This can cause performance issues on lower end devices and smart TVs.

This PR improves this in a number of ways:
* Inside our `rAF` callback, avoid synchronous re-layouts as much as possible. We now cache the bar and thumb widths more aggressively.
* Inside our `rAF` callback, check if the change in `currentTime` is large enough to be noticeable on the screen. That is: if the thumb would move by at least 1 pixel. If the change is less than that, we don't advance at all.
* If the change in `currentTime` needed to move the thumb by 1 pixel is *larger* than 250ms, then we don't run our auto-advance logic *at all*. In this case, it's sufficient to update on every `timeupdate` event, which is guaranteed to fire at least once every 250ms anyway. This improvement is especially noticeable for longer videos, where the thumb might not need to move for several seconds.