### PR TITLE
Hide forced subtitles in menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ sidebar_custom_props: { 'icon': '📰' }
 > -   🏠 Internal
 > -   💅 Polish
 
+## Unreleased
+
+-   💅 Forced subtitles are no longer shown in the subtitle menu. ([#92](https://github.com/THEOplayer/web-ui/pull/92))
+
 ## v1.9.4 (2025-02-19)
 
 -   No changes

--- a/src/components/LanguageMenu.ts
+++ b/src/components/LanguageMenu.ts
@@ -4,7 +4,7 @@ import languageMenuHtml from './LanguageMenu.html';
 import languageMenuCss from './LanguageMenu.css';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import type { ChromelessPlayer, MediaTrack, MediaTrackList, TextTrack, TextTracksList } from 'theoplayer/chromeless';
-import { isSubtitleTrack } from '../util/TrackUtils';
+import { isNonForcedSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 import { toggleAttribute } from '../util/CommonUtils';
 import { createTemplate } from '../util/TemplateUtils';
@@ -64,7 +64,7 @@ export class LanguageMenu extends StateReceiverMixin(MenuGroup, ['player']) {
     };
 
     private readonly _updateTextTracks = (): void => {
-        const newSubtitleTracks: readonly TextTrack[] = this._player?.textTracks.filter(isSubtitleTrack) ?? [];
+        const newSubtitleTracks: readonly TextTrack[] = this._player?.textTracks.filter(isNonForcedSubtitleTrack) ?? [];
         // Hide subtitle track selection if there are no tracks. If there's one, we still show an "off" option.
         toggleAttribute(this, Attribute.HAS_SUBTITLES, newSubtitleTracks.length > 0);
     };

--- a/src/components/LanguageMenuButton.ts
+++ b/src/components/LanguageMenuButton.ts
@@ -3,7 +3,7 @@ import { buttonTemplate } from './Button';
 import languageIcon from '../icons/language.svg';
 import { StateReceiverMixin } from './StateReceiverMixin';
 import type { ChromelessPlayer, MediaTrackList, TextTracksList } from 'theoplayer/chromeless';
-import { isSubtitleTrack } from '../util/TrackUtils';
+import { isNonForcedSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 import { toggleAttribute } from '../util/CommonUtils';
 import { createTemplate } from '../util/TemplateUtils';
@@ -57,7 +57,8 @@ export class LanguageMenuButton extends StateReceiverMixin(MenuButton, ['player'
     }
 
     private readonly _updateTracks = (): void => {
-        const hasTracks = this._player !== undefined && (this._player.audioTracks.length >= 2 || this._player.textTracks.some(isSubtitleTrack));
+        const hasTracks =
+            this._player !== undefined && (this._player.audioTracks.length >= 2 || this._player.textTracks.some(isNonForcedSubtitleTrack));
         toggleAttribute(this, Attribute.HIDDEN, !hasTracks);
     };
 }

--- a/src/components/TextTrackOffRadioButton.ts
+++ b/src/components/TextTrackOffRadioButton.ts
@@ -1,7 +1,7 @@
 import { RadioButton } from './RadioButton';
 import { buttonTemplate } from './Button';
 import type { TextTracksList } from 'theoplayer/chromeless';
-import { isSubtitleTrack } from '../util/TrackUtils';
+import { isNonForcedSubtitleTrack, isSubtitleTrack } from '../util/TrackUtils';
 import { Attribute } from '../util/Attribute';
 import { createTemplate } from '../util/TemplateUtils';
 
@@ -60,7 +60,7 @@ export class TextTrackOffRadioButton extends RadioButton {
 }
 
 function hasShowingSubtitleTrack(trackList: TextTracksList): boolean {
-    return trackList.filter(isSubtitleTrack).some((x) => x.mode === 'showing');
+    return trackList.filter(isNonForcedSubtitleTrack).some((x) => x.mode === 'showing');
 }
 
 function disableSubtitleTracks(trackList: TextTracksList): void {

--- a/src/components/TextTrackOffRadioButton.ts
+++ b/src/components/TextTrackOffRadioButton.ts
@@ -60,7 +60,7 @@ export class TextTrackOffRadioButton extends RadioButton {
 }
 
 function hasShowingSubtitleTrack(trackList: TextTracksList): boolean {
-    return trackList.filter(isNonForcedSubtitleTrack).some((x) => x.mode === 'showing');
+    return trackList.some((track) => isNonForcedSubtitleTrack(track) && track.mode === 'showing');
 }
 
 function disableSubtitleTracks(trackList: TextTracksList): void {

--- a/src/components/TrackRadioGroup.ts
+++ b/src/components/TrackRadioGroup.ts
@@ -6,7 +6,7 @@ import type { ChromelessPlayer, MediaTrack, MediaTrackList, TextTrack, TextTrack
 import { Attribute } from '../util/Attribute';
 import { MediaTrackRadioButton } from './MediaTrackRadioButton';
 import { TextTrackRadioButton } from './TextTrackRadioButton';
-import { isSubtitleTrack } from '../util/TrackUtils';
+import { isNonForcedSubtitleTrack } from '../util/TrackUtils';
 import { TextTrackOffRadioButton } from './TextTrackOffRadioButton';
 import { fromArrayLike, toggleAttribute } from '../util/CommonUtils';
 import { createEvent } from '../util/EventUtils';
@@ -151,7 +151,7 @@ export class TrackRadioGroup extends StateReceiverMixin(HTMLElement, ['player'])
         } else if (trackType === 'video') {
             return this._player.videoTracks;
         } else if (trackType === 'subtitles') {
-            return this._player.textTracks.filter(isSubtitleTrack);
+            return this._player.textTracks.filter(isNonForcedSubtitleTrack);
         } else {
             return [];
         }

--- a/src/util/TrackUtils.ts
+++ b/src/util/TrackUtils.ts
@@ -4,6 +4,10 @@ export function isSubtitleTrack(track: TextTrack): boolean {
     return track.kind === 'subtitles' || track.kind === 'captions';
 }
 
+export function isNonForcedSubtitleTrack(track: TextTrack): boolean {
+    return isSubtitleTrack(track) && !track.forced;
+}
+
 export function getTargetQualities(videoTrack: MediaTrack | undefined): Quality[] | undefined {
     let targetQualities = videoTrack?.targetQuality;
     if (targetQualities !== undefined && !Array.isArray(targetQualities)) {


### PR DESCRIPTION
Forced subtitles should not be selectable by the user. Instead, the player will select them automatically when applicable.