### PR TITLE
Fix issue with AdClickThroughButton component when loaded in React context

### DIFF
--- a/src/components/ads/AdClickThroughButton.ts
+++ b/src/components/ads/AdClickThroughButton.ts
@@ -27,9 +27,6 @@ export class AdClickThroughButton extends StateReceiverMixin(LinkButton, ['playe
     constructor() {
         super({ template: template() });
 
-        this.disabled = true;
-        this.style.display = 'none';
-
         this._upgradeProperty('clickThrough');
         this._upgradeProperty('player');
     }
@@ -37,6 +34,9 @@ export class AdClickThroughButton extends StateReceiverMixin(LinkButton, ['playe
     override connectedCallback(): void {
         super.connectedCallback();
         this._updateFromPlayer();
+
+        this.disabled = true;
+        this.style.display = 'none';
     }
 
     get clickThrough(): string | null {


### PR DESCRIPTION
There is a problem with the `AdClickThroughButton` when loaded into a React application. It is triggering the following error:

```
Failed to execute 'createElement' on 'Document': The result must not have attributes
NotSupportedError: Failed to execute 'createElement' on 'Document': The result must not have attributes
    at createElement (http://localhost:3000/static/js/bundle.js:15863:38)
    at createInstance (http://localhost:3000/static/js/bundle.js:16852:24)
    at completeWork (http://localhost:3000/static/js/bundle.js:26502:32)
    at completeUnitOfWork (http://localhost:3000/static/js/bundle.js:30261:20)
    at performUnitOfWork (http://localhost:3000/static/js/bundle.js:30237:9)
    at workLoopSync (http://localhost:3000/static/js/bundle.js:30151:9)
    at renderRootSync (http://localhost:3000/static/js/bundle.js:30124:11)
    at performSyncWorkOnRoot (http://localhost:3000/static/js/bundle.js:29816:24)
    at flushSyncCallbacks (http://localhost:3000/static/js/bundle.js:17817:26)
    at flushSync (http://localhost:3000/static/js/bundle.js:29920:11)
```

Note: when loaded in a vanilla javascript, the component loads properly.