### PR TITLE
Fix language and settings menu not displaying correctly on older smart TVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ sidebar_custom_props: { 'icon': '📰' }
 > -   🏠 Internal
 > -   💅 Polish
 
+## Unreleased
+
+-   🐛 Fix language and settings menu not displaying correctly on older smart TVs. ([#108](https://github.com/THEOplayer/web-ui/pull/108))
+
 ## v1.11.3 (2025-07-22)
 
 -   🐛 Fix issue with the `<theoplayer-ad-clickthrough-button>` component that was triggering the error `Failed to execute 'createElement' on 'Document': The result must not have attributes` when loaded into a React application. ([#106](https://github.com/THEOplayer/web-ui/pull/106))

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -126,7 +126,7 @@ function jsPlugins({ es5 = false, node = false, module = false, production = fal
             plugins: [
                 postcssPresetEnv({
                     browsers: browserslist,
-                    autoprefixer: { grid: 'no-autoplace' },
+                    autoprefixer: { grid: false },
                     enableClientSidePolyfills: false
                 }),
                 postcssMixins()

--- a/src/components/MenuTable.css
+++ b/src/components/MenuTable.css
@@ -1,17 +1,31 @@
-/* autoprefixer grid: autoplace */
 .theoplayer-menu-table {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    grid-template-rows: auto auto;
+    table-layout: auto;
+    border-collapse: collapse;
 }
 
-.theoplayer-menu-table > * {
-    align-self: center;
+.theoplayer-menu-table,
+.theoplayer-menu-table tr,
+.theoplayer-menu-table td {
+    margin: 0;
+    padding: 0;
+}
+
+.theoplayer-menu-table td > * {
     font-size: var(--theoplayer-text-font-size, 14px);
     line-height: var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px));
     padding: var(--theoplayer-control-padding, 10px);
 }
 
-.theoplayer-menu-table > span {
-    display: block;
+.theoplayer-menu-table td:first-child {
+    width: 0;
+    white-space: nowrap;
+}
+
+.theoplayer-menu-table td:last-child {
+    text-align: center;
+}
+
+.theoplayer-menu-table td > theoplayer-menu-button {
+    /* Fill entire cell */
+    display: flex;
 }

--- a/src/components/SettingsMenu.html
+++ b/src/components/SettingsMenu.html
@@ -1,15 +1,23 @@
 <theoplayer-menu>
     <span slot="heading"><slot name="heading">Settings</slot></span>
-    <div class="theoplayer-menu-table">
-        <span>Quality</span>
-        <theoplayer-menu-button menu="quality-menu">
-            <theoplayer-active-quality-display></theoplayer-active-quality-display>
-        </theoplayer-menu-button>
-        <span>Playback speed</span>
-        <theoplayer-menu-button menu="playback-rate-menu">
-            <theoplayer-playback-rate-display></theoplayer-playback-rate-display>
-        </theoplayer-menu-button>
-    </div>
+    <table class="theoplayer-menu-table">
+        <tr>
+            <td><span>Quality</span></td>
+            <td>
+                <theoplayer-menu-button menu="quality-menu">
+                    <theoplayer-active-quality-display></theoplayer-active-quality-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Playback speed</span></td>
+            <td>
+                <theoplayer-menu-button menu="playback-rate-menu">
+                    <theoplayer-playback-rate-display></theoplayer-playback-rate-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+    </table>
 </theoplayer-menu>
 <theoplayer-menu id="quality-menu" menu-close-on-input hidden>
     <span slot="heading">Quality</span>

--- a/src/components/TextTrackStyleMenu.html
+++ b/src/components/TextTrackStyleMenu.html
@@ -1,44 +1,80 @@
 <theoplayer-menu class="theoplayer-text-track-style-menu">
     <span class="theoplayer-menu-heading" slot="heading"><slot name="heading">Subtitle options</slot></span>
     <theoplayer-text-track-style-reset-button class="theoplayer-menu-heading-button" slot="heading"></theoplayer-text-track-style-reset-button>
-    <div class="theoplayer-menu-table">
-        <span>Font family</span>
-        <theoplayer-menu-button menu="font-family-menu">
-            <theoplayer-text-track-style-display property="fontFamily"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-        <span>Font color</span>
-        <theoplayer-menu-button menu="font-color-menu">
-            <theoplayer-text-track-style-display property="fontColor"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-        <span>Font opacity</span>
-        <theoplayer-menu-button menu="font-opacity-menu">
-            <theoplayer-text-track-style-display property="fontOpacity"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-        <span>Font size</span>
-        <theoplayer-menu-button menu="font-size-menu">
-            <theoplayer-text-track-style-display property="fontSize"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-        <span>Background color</span>
-        <theoplayer-menu-button menu="background-color-menu">
-            <theoplayer-text-track-style-display property="backgroundColor"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-        <span>Background opacity</span>
-        <theoplayer-menu-button menu="background-opacity-menu">
-            <theoplayer-text-track-style-display property="backgroundOpacity"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-        <span>Window color</span>
-        <theoplayer-menu-button menu="window-color-menu">
-            <theoplayer-text-track-style-display property="windowColor"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-        <span>Window opacity</span>
-        <theoplayer-menu-button menu="window-opacity-menu">
-            <theoplayer-text-track-style-display property="windowOpacity"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-        <span>Character edge style</span>
-        <theoplayer-menu-button menu="edge-style-menu">
-            <theoplayer-text-track-style-display property="edgeStyle"></theoplayer-text-track-style-display>
-        </theoplayer-menu-button>
-    </div>
+    <table class="theoplayer-menu-table">
+        <tr>
+            <td><span>Font family</span></td>
+            <td>
+                <theoplayer-menu-button menu="font-family-menu">
+                    <theoplayer-text-track-style-display property="fontFamily"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Font color</span></td>
+            <td>
+                <theoplayer-menu-button menu="font-color-menu">
+                    <theoplayer-text-track-style-display property="fontColor"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Font opacity</span></td>
+            <td>
+                <theoplayer-menu-button menu="font-opacity-menu">
+                    <theoplayer-text-track-style-display property="fontOpacity"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Font size</span></td>
+            <td>
+                <theoplayer-menu-button menu="font-size-menu">
+                    <theoplayer-text-track-style-display property="fontSize"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Background color</span></td>
+            <td>
+                <theoplayer-menu-button menu="background-color-menu">
+                    <theoplayer-text-track-style-display property="backgroundColor"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Background opacity</span></td>
+            <td>
+                <theoplayer-menu-button menu="background-opacity-menu">
+                    <theoplayer-text-track-style-display property="backgroundOpacity"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Window color</span></td>
+            <td>
+                <theoplayer-menu-button menu="window-color-menu">
+                    <theoplayer-text-track-style-display property="windowColor"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Window opacity</span></td>
+            <td>
+                <theoplayer-menu-button menu="window-opacity-menu">
+                    <theoplayer-text-track-style-display property="windowOpacity"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+        <tr>
+            <td><span>Character edge style</span></td>
+            <td>
+                <theoplayer-menu-button menu="edge-style-menu">
+                    <theoplayer-text-track-style-display property="edgeStyle"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </td>
+        </tr>
+    </table>
 </theoplayer-menu>
 <theoplayer-menu id="font-family-menu" menu-close-on-input hidden>
     <span slot="heading">Font family</span>


### PR DESCRIPTION
Older smart TVs don't support `display: grid`, and [Autoprefixer's Grid Autoplacement](https://github.com/postcss/autoprefixer/blob/10.4.21/README.md#grid-autoplacement-support-in-ie) only works on Internet Explorer. So instead, we just use a `<table>` like it's 1999. 😅