### PR TITLE
Fix #108

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ sidebar_custom_props: { 'icon': '📰' }
 
 ## Unreleased
 
--   🐛 Fix language and settings menu not displaying correctly on older smart TVs. ([#108](https://github.com/THEOplayer/web-ui/pull/108))
+-   🐛 Fix settings menu and subtitle options menu not displaying correctly on older smart TVs. ([#108](https://github.com/THEOplayer/web-ui/pull/108), [#109](https://github.com/THEOplayer/web-ui/pull/109))
 
 ## v1.11.3 (2025-07-22)
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -126,7 +126,7 @@ function jsPlugins({ es5 = false, node = false, module = false, production = fal
             plugins: [
                 postcssPresetEnv({
                     browsers: browserslist,
-                    autoprefixer: { grid: false },
+                    autoprefixer: { grid: 'no-autoplace' },
                     enableClientSidePolyfills: false
                 }),
                 postcssMixins()


### PR DESCRIPTION
We're still using `display: grid`, so keep Autoprefixer's grid support turned on for now. (See https://github.com/THEOplayer/web-ui/pull/108#issuecomment-3112869475)