### PR TITLE
Fill entire window when fullscreen is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ sidebar_custom_props: { 'icon': '📰' }
 
 ## Unreleased
 
+-   🚀 Fill the entire window when fullscreen is not natively supported. ([#94](https://github.com/THEOplayer/web-ui/issues/94), [#110](https://github.com/THEOplayer/web-ui/pull/110))
 -   🐛 Fix settings menu and subtitle options menu not displaying correctly on older smart TVs. ([#108](https://github.com/THEOplayer/web-ui/pull/108), [#109](https://github.com/THEOplayer/web-ui/pull/109))
 
 ## v1.11.3 (2025-07-22)

--- a/src/Global.css
+++ b/src/Global.css
@@ -1,0 +1,11 @@
+/* Full window */
+html.theoplayer-ui-full-window {
+    overflow: hidden !important;
+
+    & > body {
+        width: 100% !important;
+        height: 100% !important;
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+}

--- a/src/Global.ts
+++ b/src/Global.ts
@@ -1,0 +1,20 @@
+import globalCss from './Global.css';
+
+const GLOBAL_STYLE_ID = 'theoplayer-ui-global-styles';
+
+let globalStylesAdded = false;
+
+export function addGlobalStyles() {
+    if (globalStylesAdded) {
+        return;
+    }
+    if (document.getElementById(GLOBAL_STYLE_ID)) {
+        globalStylesAdded = true;
+        return;
+    }
+    const styleEl = document.createElement('style');
+    styleEl.id = GLOBAL_STYLE_ID;
+    styleEl.innerHTML = globalCss;
+    document.head.appendChild(styleEl);
+    globalStylesAdded = true;
+}

--- a/src/Global.ts
+++ b/src/Global.ts
@@ -1,4 +1,5 @@
 import globalCss from './Global.css';
+import { setTextContent } from './util/CommonUtils';
 
 const GLOBAL_STYLE_ID = 'theoplayer-ui-global-styles';
 
@@ -14,7 +15,7 @@ export function addGlobalStyles() {
     }
     const styleEl = document.createElement('style');
     styleEl.id = GLOBAL_STYLE_ID;
-    styleEl.innerHTML = globalCss;
+    setTextContent(styleEl, globalCss);
     document.head.appendChild(styleEl);
     globalStylesAdded = true;
 }

--- a/src/UIContainer.css
+++ b/src/UIContainer.css
@@ -31,6 +31,13 @@
     @mixin fullscreen-styles;
 }
 
+:host([fullwindow]) {
+    position: fixed !important;
+    inset: 0 !important;
+    z-index: 1000 !important;
+    overflow: hidden !important;
+}
+
 :host([fluid]) {
     padding-bottom: calc(100% * var(--theoplayer-video-height, 9) / var(--theoplayer-video-width, 16));
 }

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -36,6 +36,7 @@ import { getFocusedChild, navigateByArrowKey } from './util/KeyboardNavigation';
 import { isArrowKey, isBackKey, KeyCode } from './util/KeyCode';
 import { READY_EVENT } from './events/ReadyEvent';
 import { createTemplate } from './util/TemplateUtils';
+import { addGlobalStyles } from './Global';
 
 // Load components used in template
 import './components/GestureReceiver';
@@ -45,6 +46,7 @@ const template = createTemplate('theoplayer-ui', `<style>${elementCss}</style>${
 const DEFAULT_USER_IDLE_TIMEOUT = 2;
 const DEFAULT_TV_USER_IDLE_TIMEOUT = 5;
 const DEFAULT_DVR_THRESHOLD = 60;
+const FULL_WINDOW_ROOT_CLASS = 'theoplayer-ui-full-window';
 
 /**
  * `<theoplayer-ui>` - The container element for a THEOplayer UI.
@@ -379,6 +381,7 @@ export class UIContainer extends HTMLElement {
 
     connectedCallback(): void {
         shadyCss.styleElement(this);
+        addGlobalStyles();
 
         if (!(this._menuGroup instanceof MenuGroup)) {
             customElements.upgrade(this._menuGroup);
@@ -733,6 +736,7 @@ export class UIContainer extends HTMLElement {
         } else if (!this._fullWindow) {
             this._fullWindow = true;
             toggleAttribute(this, Attribute.FULLWINDOW, true);
+            document.documentElement.classList.add(FULL_WINDOW_ROOT_CLASS);
             window.addEventListener('keydown', this._exitFullscreenOnEsc);
             this._onFullscreenChange();
         }
@@ -753,6 +757,7 @@ export class UIContainer extends HTMLElement {
         if (this._fullWindow) {
             this._fullWindow = false;
             toggleAttribute(this, Attribute.FULLWINDOW, false);
+            document.documentElement.classList.remove(FULL_WINDOW_ROOT_CLASS);
             window.removeEventListener('keydown', this._exitFullscreenOnEsc);
             this._onFullscreenChange();
         }

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -162,7 +162,6 @@ export class UIContainer extends HTMLElement {
     private _source: SourceDescription | undefined = undefined;
     private _userIdleTimer: number = 0;
     private _previewTime: number = NaN;
-    private _fullWindow: boolean = false;
     private _activeVideoTrack: MediaTrack | undefined = undefined;
 
     /**
@@ -420,7 +419,7 @@ export class UIContainer extends HTMLElement {
         if (this.deviceType === 'tv') {
             window.addEventListener('keydown', this._onTvKeyDown);
         }
-        if (this._fullWindow) {
+        if (this.hasAttribute(Attribute.FULLWINDOW)) {
             window.addEventListener('keydown', this._exitFullscreenOnEsc);
         }
         this.addEventListener('keyup', this._onKeyUp);
@@ -733,8 +732,7 @@ export class UIContainer extends HTMLElement {
             }
         } else if (this._player && this._player.presentation.supportsMode('fullscreen')) {
             this._player.presentation.requestMode('fullscreen');
-        } else if (!this._fullWindow) {
-            this._fullWindow = true;
+        } else if (!this.hasAttribute(Attribute.FULLWINDOW)) {
             toggleAttribute(this, Attribute.FULLWINDOW, true);
             document.documentElement.classList.add(FULL_WINDOW_ROOT_CLASS);
             window.addEventListener('keydown', this._exitFullscreenOnEsc);
@@ -754,8 +752,7 @@ export class UIContainer extends HTMLElement {
         if (this._player && this._player.presentation.currentMode === 'fullscreen') {
             this._player.presentation.requestMode('inline');
         }
-        if (this._fullWindow) {
-            this._fullWindow = false;
+        if (this.hasAttribute(Attribute.FULLWINDOW)) {
             toggleAttribute(this, Attribute.FULLWINDOW, false);
             document.documentElement.classList.remove(FULL_WINDOW_ROOT_CLASS);
             window.removeEventListener('keydown', this._exitFullscreenOnEsc);
@@ -777,7 +774,7 @@ export class UIContainer extends HTMLElement {
         if (!isFullscreen && this._player !== undefined && this._player.presentation.currentMode === 'fullscreen') {
             isFullscreen = true;
         }
-        if (this._fullWindow) {
+        if (this.hasAttribute(Attribute.FULLWINDOW)) {
             isFullscreen = true;
         }
         toggleAttribute(this, Attribute.FULLSCREEN, isFullscreen);

--- a/src/util/Attribute.ts
+++ b/src/util/Attribute.ts
@@ -4,6 +4,7 @@ export enum Attribute {
     AUTOPLAY = 'autoplay',
     MUTED = 'muted',
     FULLSCREEN = 'fullscreen',
+    FULLWINDOW = 'fullwindow',
     FLUID = 'fluid',
     DEVICE_TYPE = 'device-type',
     MOBILE = 'mobile',


### PR DESCRIPTION
If fullscreen mode is not supported by the [standard Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API) nor the [THEOplayer Presentation API](https://optiview.dolby.com/docs/theoplayer/v9/api-reference/web/interfaces/Presentation.html), then we will now make the UI fill the entire window instead.

Fixes #94.