### PR TITLE
Fix repeated seeks during playback on Safari

### DIFF
--- a/.changeset/grumpy-cougars-count.md
+++ b/.changeset/grumpy-cougars-count.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/web-ui': patch
+---
+
+Fixed `<theoplayer-time-range>` repeatedly triggering seeks when updating its value from the player's current time, which caused noticeable stutters on Safari.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@theoplayer/web-ui",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@theoplayer/web-ui",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "workspaces": [
         ".",
@@ -10470,11 +10470,11 @@
     },
     "react": {
       "name": "@theoplayer/react-ui",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@lit/react": "^1.0.8",
-        "@theoplayer/web-ui": "^2.0.0"
+        "@theoplayer/web-ui": "^2.1.0"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^6.1.0",

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -28,8 +28,7 @@ export abstract class Range extends LitElement {
 
     private _min: number = 0;
     private _max: number = 100;
-    @state()
-    private accessor _value: number = 0;
+    private _value: number = 0;
     private _disabled: boolean = false;
     private _hidden: boolean = false;
     private _inert: boolean = false;
@@ -99,7 +98,7 @@ export abstract class Range extends LitElement {
      * The current value.
      */
     get value(): number {
-        return this._value;
+        return this.rawValue;
     }
 
     @property({ reflect: false, attribute: false })
@@ -111,18 +110,24 @@ export abstract class Range extends LitElement {
         if (!isNaN(this.max)) {
             newValue = Math.min(this.max, newValue);
         }
-        if (this._value === newValue) return;
-        this.updateValue(newValue);
+        if (this.rawValue === newValue) return;
+        this.rawValue = newValue;
         this.handleInput();
     }
 
     /**
-     * Update the current value *without* triggering {@link handleInput}.
+     * The current value.
      *
+     * Setting this property does *not* trigger {@link handleInput}.
      * This should be used when synchronizing the range with external state,
      * e.g. when updating the value of a time range with the player's current time.
      */
-    protected updateValue(value: number) {
+    protected get rawValue() {
+        return this._value;
+    }
+
+    @state()
+    protected set rawValue(value: number) {
         this._value = value;
     }
 
@@ -308,7 +313,7 @@ export abstract class Range extends LitElement {
                 .min=${this.min}
                 .max=${this.max}
                 .step=${this.step}
-                .valueAsNumber=${this.value}
+                .valueAsNumber=${this.rawValue}
                 .disabled=${this.disabled || this.inert}
                 aria-label="${this.getAriaLabel()}"
                 aria-valuetext=${this.getAriaValueText()}

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -28,7 +28,8 @@ export abstract class Range extends LitElement {
 
     private _min: number = 0;
     private _max: number = 100;
-    private _value: number = 0;
+    @state()
+    private accessor _value: number = 0;
     private _disabled: boolean = false;
     private _hidden: boolean = false;
     private _inert: boolean = false;
@@ -111,8 +112,18 @@ export abstract class Range extends LitElement {
             newValue = Math.min(this.max, newValue);
         }
         if (this._value === newValue) return;
-        this._value = newValue;
+        this.updateValue(newValue);
         this.handleInput();
+    }
+
+    /**
+     * Update the current value *without* triggering {@link handleInput}.
+     *
+     * This should be used when synchronizing the range with external state,
+     * e.g. when updating the value of a time range with the player's current time.
+     */
+    protected updateValue(value: number) {
+        this._value = value;
     }
 
     /**

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -297,7 +297,7 @@ export abstract class Range extends LitElement {
                 .min=${this.min}
                 .max=${this.max}
                 .step=${this.step}
-                .value=${this.value}
+                .valueAsNumber=${this.value}
                 .disabled=${this.disabled || this.inert}
                 aria-label="${this.getAriaLabel()}"
                 aria-valuetext=${this.getAriaValueText()}

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -159,7 +159,7 @@ export class TimeRange extends Range {
         }
         this.min = min;
         this.max = max;
-        this.value = value;
+        this.updateValue(value);
         this.updateDisabled_(seekable);
     };
 
@@ -269,7 +269,7 @@ export class TimeRange extends Range {
         const delta = (performance.now() - this._lastUpdateTime) / 1000;
         const newValue = this._lastCurrentTime + delta * this._lastPlaybackRate;
         if (Math.abs(newValue - this.value) >= this.getMinimumStepForVisibleChange_()) {
-            this.value = newValue;
+            this.updateValue(newValue);
 
             // Use cached width to avoid synchronous layout
             this._updateRange(/* useCachedWidth = */ true);

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -159,7 +159,7 @@ export class TimeRange extends Range {
         }
         this.min = min;
         this.max = max;
-        this.updateValue(value);
+        this.rawValue = value;
         this.updateDisabled_(seekable);
     };
 
@@ -269,7 +269,7 @@ export class TimeRange extends Range {
         const delta = (performance.now() - this._lastUpdateTime) / 1000;
         const newValue = this._lastCurrentTime + delta * this._lastPlaybackRate;
         if (Math.abs(newValue - this.value) >= this.getMinimumStepForVisibleChange_()) {
-            this.updateValue(newValue);
+            this.rawValue = newValue;
 
             // Use cached width to avoid synchronous layout
             this._updateRange(/* useCachedWidth = */ true);

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -161,6 +161,7 @@ export class TimeRange extends Range {
         this.max = max;
         this.rawValue = value;
         this.updateDisabled_(seekable);
+        this._updateRange();
     };
 
     private updateDisabled_(seekable: TimeRanges | undefined = this._player?.seekable) {

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -52,7 +52,7 @@ export class VolumeRange extends Range {
 
     private readonly _updateFromPlayer = () => {
         if (this._player !== undefined) {
-            this.value = this._player.volume;
+            this.updateValue(this._player.volume);
         }
     };
 

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -53,6 +53,7 @@ export class VolumeRange extends Range {
     private readonly _updateFromPlayer = () => {
         if (this._player !== undefined) {
             this.rawValue = this._player.volume;
+            this._updateRange();
         }
     };
 

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -52,7 +52,7 @@ export class VolumeRange extends Range {
 
     private readonly _updateFromPlayer = () => {
         if (this._player !== undefined) {
-            this.updateValue(this._player.volume);
+            this.rawValue = this._player.volume;
         }
     };
 


### PR DESCRIPTION
On macOS and iOS Safari, the player was triggering repeated seeks during playback, leading to very noticeable stuttering.

The problem was that `TimeRange._updateFromPlayer` would set `this.value`, which would always call `this.handleInput()` and as such trigger a seek on the player. This is a regression in version 2.0.0: in 1.x, `_updateFromPlayer` would not go through `this.value` and would instead set the new value directly on the `<input type=range>`.

I fixed it by reviving some lost logic from 1.x: we now go through the new `this.rawValue` instead, which deliberately **does not** call `handleInput()`.