### PR TITLE
Document custom CSS properties

### DIFF
--- a/.idea/prettier.xml
+++ b/.idea/prettier.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="PrettierConfiguration">
+    <option name="myConfigurationMode" value="AUTOMATIC" />
     <option name="myRunOnSave" value="true" />
     <option name="myRunOnReformat" value="true" />
-    <option name="myFilesPattern" value="{**/*,*}.{js,ts,jsx,tsx,mjs,css,html}" />
+    <option name="myFilesPattern" value="{**/*,*}.{js,ts,jsx,tsx,mjs,mts,css,html}" />
   </component>
 </project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@theoplayer/web-ui",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@theoplayer/web-ui",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "workspaces": [
         ".",
@@ -30,6 +30,7 @@
         "@types/html-minifier": "^4.0.6",
         "@webcomponents/shadycss": "^1.11.2",
         "cross-env": "^10.1.0",
+        "htm": "^3.1.1",
         "html-minifier": "^4.0.0",
         "postcss": "^8.5.10",
         "postcss-mixins": "^12.1.2",
@@ -5915,6 +5916,13 @@
         "he": "bin/he"
       }
     },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/html-minifier": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
@@ -10470,11 +10478,11 @@
     },
     "react": {
       "name": "@theoplayer/react-ui",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@lit/react": "^1.0.8",
-        "@theoplayer/web-ui": "^2.1.0"
+        "@theoplayer/web-ui": "^2.1.1"
       },
       "devDependencies": {
         "@rollup/plugin-json": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/html-minifier": "^4.0.6",
     "@webcomponents/shadycss": "^1.11.2",
     "cross-env": "^10.1.0",
+    "htm": "^3.1.1",
     "html-minifier": "^4.0.0",
     "postcss": "^8.5.10",
     "postcss-mixins": "^12.1.2",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"]
+  },
+  "include": ["**/*"]
+}

--- a/scripts/typedoc-collapsible-tags.mts
+++ b/scripts/typedoc-collapsible-tags.mts
@@ -1,0 +1,112 @@
+import { Application, type CommentDisplayPart, CommentTag, DefaultThemeRenderContext, i18n, JSX, translateTagName } from 'typedoc';
+
+type CollapsibleTag = { tag: `@${string}`; heading: string; columnHeading: string };
+
+const collapsibleTags: ReadonlyArray<CollapsibleTag> = [
+    { tag: '@attribute', heading: 'Attributes', columnHeading: 'Attribute' },
+    { tag: '@slot', heading: 'Slots', columnHeading: 'Slot' },
+    { tag: '@cssproperty', heading: 'CSS Custom Properties', columnHeading: 'Property' }
+];
+
+/**
+ * Render all `commentTags` as a single `<table>`.
+ */
+function commentTagTable(context: DefaultThemeRenderContext, tag: CollapsibleTag, commentTags: CommentTag[]) {
+    const tagName = translateTagName(tag.tag);
+    const anchor = context.slugger.slug(tagName);
+    // Using JSX.createElement directly just to avoid needing a compilation step to run TypeDoc.
+    return JSX.createElement(
+        'div',
+        { class: `tsd-tag-${tag.tag.substring(1)}` },
+        JSX.createElement('h4', { class: 'tsd-anchor-link', id: anchor }, tag.heading, anchorIcon(context, anchor)),
+        JSX.createElement(
+            'table',
+            null,
+            JSX.createElement(
+                'thead',
+                null,
+                JSX.createElement('tr', null, JSX.createElement('th', null, tag.columnHeading), JSX.createElement('th', null, 'Description'))
+            ),
+            JSX.createElement(
+                'tbody',
+                null,
+                commentTags.map((t) => {
+                    const { name, description } = parseNamedRow(t.content);
+                    return JSX.createElement(
+                        'tr',
+                        null,
+                        JSX.createElement('td', null, JSX.createElement(JSX.Raw, { html: context.markdown(name) })),
+                        JSX.createElement('td', null, JSX.createElement(JSX.Raw, { html: context.markdown(description) }))
+                    );
+                })
+            )
+        )
+    );
+}
+
+// https://github.com/TypeStrong/typedoc/blob/v0.28.19/src/lib/output/themes/default/partials/anchor-icon.tsx
+function anchorIcon(context: DefaultThemeRenderContext, anchor: string | undefined) {
+    if (!anchor) return JSX.createElement(JSX.Fragment, null);
+    return JSX.createElement(
+        'a',
+        {
+            href: `#${anchor}`,
+            'aria-label': i18n.theme_permalink(),
+            class: 'tsd-anchor-icon'
+        },
+        context.icons.anchor()
+    );
+}
+
+/**
+ * Parses a block tag's content into a `name` and `description` pair, preserving the
+ * original display parts (including inline tags) in each.
+ */
+function parseNamedRow(parts: ReadonlyArray<CommentDisplayPart>): {
+    name: CommentDisplayPart[];
+    description: CommentDisplayPart[];
+} {
+    const name: CommentDisplayPart[] = [];
+    const description: CommentDisplayPart[] = [];
+    let inDescription = false;
+    for (const part of parts) {
+        if (inDescription) {
+            description.push(part);
+            continue;
+        }
+        if (part.kind === 'text') {
+            const match = part.text.match(/\s+-\s+/);
+            if (match) {
+                const { 0: matchedString, index: matchIndex } = match;
+                const before = part.text.substring(0, matchIndex!);
+                const after = part.text.substring(matchIndex! + matchedString.length);
+                if (before) name.push({ kind: 'text', text: before });
+                if (after) description.push({ kind: 'text', text: after });
+                inDescription = true;
+                continue;
+            }
+        }
+        name.push(part);
+    }
+    return { name, description };
+}
+
+export function load(app: Application) {
+    app.renderer.hooks.on('comment.afterTags', (context, comment, _props) => {
+        const tables: JSX.Element[] = [];
+        for (const tag of collapsibleTags) {
+            const commentTags = comment.blockTags.filter((t) => t.tag === tag.tag);
+            if (commentTags.length < 2) {
+                // Keep single entries as-is for simplicity.
+            } else {
+                // Take over rendering for these tags.
+                commentTags.forEach((t) => (t.skipRendering = true));
+                // Render them all as a single table.
+                tables.push(commentTagTable(context, tag, commentTags));
+            }
+        }
+        return tables.length === 0
+            ? JSX.createElement(JSX.Fragment, null)
+            : JSX.createElement('div', { class: 'tsd-comment tsd-typography' }, tables);
+    });
+}

--- a/scripts/typedoc-collapsible-tags.mts
+++ b/scripts/typedoc-collapsible-tags.mts
@@ -1,4 +1,7 @@
 import { Application, type CommentDisplayPart, CommentTag, DefaultThemeRenderContext, i18n, JSX, translateTagName } from 'typedoc';
+import htm from 'htm';
+
+const html = htm.bind(JSX.createElement);
 
 type CollapsibleTag = { tag: `@${string}`; heading: string; columnHeading: string };
 
@@ -14,48 +17,34 @@ const collapsibleTags: ReadonlyArray<CollapsibleTag> = [
 function commentTagTable(context: DefaultThemeRenderContext, tag: CollapsibleTag, commentTags: CommentTag[]) {
     const tagName = translateTagName(tag.tag);
     const anchor = context.slugger.slug(tagName);
-    // Using JSX.createElement directly just to avoid needing a compilation step to run TypeDoc.
-    return JSX.createElement(
-        'div',
-        { class: `tsd-tag-${tag.tag.substring(1)}` },
-        JSX.createElement('h4', { class: 'tsd-anchor-link', id: anchor }, tag.heading, anchorIcon(context, anchor)),
-        JSX.createElement(
-            'table',
-            null,
-            JSX.createElement(
-                'thead',
-                null,
-                JSX.createElement('tr', null, JSX.createElement('th', null, tag.columnHeading), JSX.createElement('th', null, 'Description'))
-            ),
-            JSX.createElement(
-                'tbody',
-                null,
-                commentTags.map((t) => {
+    return html`<div class=${`tsd-tag-${tag.tag.substring(1)}`}>
+        <h4 class="tsd-anchor-link" id="${anchor}">${tag.heading} ${anchorIcon(context, anchor)}</h4>
+        <table>
+            <thead>
+                <tr>
+                    <th>${tag.columnHeading}</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                ${commentTags.map((t) => {
                     const { name, description } = parseNamedRow(t.content);
-                    return JSX.createElement(
-                        'tr',
-                        null,
-                        JSX.createElement('td', null, JSX.createElement(JSX.Raw, { html: context.markdown(name) })),
-                        JSX.createElement('td', null, JSX.createElement(JSX.Raw, { html: context.markdown(description) }))
-                    );
-                })
-            )
-        )
-    );
+                    return html`
+                        <tr>
+                            <td><${JSX.Raw} html=${context.markdown(name)} /></td>
+                            <td><${JSX.Raw} html=${context.markdown(description)} /></td>
+                        </tr>
+                    `;
+                })}
+            </tbody>
+        </table>
+    </div>`;
 }
 
 // https://github.com/TypeStrong/typedoc/blob/v0.28.19/src/lib/output/themes/default/partials/anchor-icon.tsx
 function anchorIcon(context: DefaultThemeRenderContext, anchor: string | undefined) {
-    if (!anchor) return JSX.createElement(JSX.Fragment, null);
-    return JSX.createElement(
-        'a',
-        {
-            href: `#${anchor}`,
-            'aria-label': i18n.theme_permalink(),
-            class: 'tsd-anchor-icon'
-        },
-        context.icons.anchor()
-    );
+    if (!anchor) return html``;
+    return html`<a href=${`#${anchor}`} aria-label=${i18n.theme_permalink()} class="tsd-anchor-icon">${context.icons.anchor()}</a>`;
 }
 
 /**

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -64,6 +64,28 @@ import { createCustomEvent } from './util/EventUtils';
  * @slot `menu` - A slot for extra menus (see {@link Menu | `<theoplayer-menu>`}).
  * @slot `error` - A slot for an error display, to show when the player encounters a fatal error.
  *   By default, this shows an {@link ErrorDisplay | `<theoplayer-error-display>`}.
+ *
+ * @cssproperty `--theoplayer-control-background-gradient-stops` - The gradient stops used for the subtle
+ *   backdrop gradient behind the top and bottom control bars on desktop. Defaults to a smooth
+ *   transparent-to-black gradient.
+ * @cssproperty `--theoplayer-mobile-control-backdrop-background` - The background applied to the entire player
+ *   on mobile when the controls are shown. Defaults to `rgba(0, 0, 0, 0.5)`.
+ * @cssproperty `--theoplayer-centered-chrome-button-icon-width` - The icon width of buttons in the centered
+ *   chrome slot. Defaults to `48px`.
+ * @cssproperty `--theoplayer-centered-chrome-control-height` - The control height of elements in the centered
+ *   chrome slot. Defaults to `48px`.
+ * @cssproperty `--theoplayer-center-play-button-icon-color` - The icon color of the centered play button.
+ *   Defaults to `unset`.
+ * @cssproperty `--theoplayer-time-range-control-height` - The control height of the time range (seek bar).
+ *   Defaults to `12px`.
+ * @cssproperty `--theoplayer-time-range-track-pointer-background` - The background of the hover/preview pointer
+ *   on the time range. Defaults to `rgba(255, 255, 255, 0.5)`.
+ * @cssproperty `--theoplayer-volume-range-track-width` - The width of the volume range track when expanded on hover.
+ *   Defaults to `70px`.
+ * @cssproperty `--theoplayer-ad-chrome-control-height` - The control height for elements inside the ad chrome.
+ *   Defaults to `12px`.
+ * @cssproperty `--theoplayer-ad-control-height` - The control height of playback controls while an ad is playing.
+ *   Defaults to `16px`.
  */
 @customElement('theoplayer-default-ui')
 export class DefaultUI extends LitElement {

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -65,6 +65,9 @@ import { createCustomEvent } from './util/EventUtils';
  * @slot `error` - A slot for an error display, to show when the player encounters a fatal error.
  *   By default, this shows an {@link ErrorDisplay | `<theoplayer-error-display>`}.
  *
+ * @cssproperty `--theoplayer-text-font-size` - The font size of any text inside a control. Defaults to `14px`.
+ * @cssproperty `--theoplayer-control-height` - The height of a control. Defaults to `24px`.
+ * @cssproperty `--theoplayer-control-padding` - The padding around a control. Defaults to `10px`.
  * @cssproperty `--theoplayer-control-background-gradient-stops` - The gradient stops used for the subtle
  *   backdrop gradient behind the top and bottom control bars on desktop. Defaults to a smooth
  *   transparent-to-black gradient.

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -79,7 +79,7 @@ import { createCustomEvent } from './util/EventUtils';
  * @cssproperty `--theoplayer-centered-chrome-control-height` - The control height of elements in the centered
  *   chrome slot. Defaults to `48px`.
  * @cssproperty `--theoplayer-center-play-button-icon-color` - The icon color of the centered play button.
- *   Defaults to `unset`.
+ *   Overrides `--theoplayer-play-button-icon-color` for this button. Defaults to `unset`.
  * @cssproperty `--theoplayer-time-range-control-height` - The control height of the time range (seek bar).
  *   Defaults to `12px`.
  * @cssproperty `--theoplayer-time-range-track-pointer-background` - The background of the hover/preview pointer

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -65,6 +65,7 @@ import { createCustomEvent } from './util/EventUtils';
  * @slot `error` - A slot for an error display, to show when the player encounters a fatal error.
  *   By default, this shows an {@link ErrorDisplay | `<theoplayer-error-display>`}.
  *
+ * @cssproperty `--theoplayer-text-color` - The text color of a control. Defaults to `#fff`.
  * @cssproperty `--theoplayer-text-font-size` - The font size of any text inside a control. Defaults to `14px`.
  * @cssproperty `--theoplayer-control-height` - The height of a control. Defaults to `24px`.
  * @cssproperty `--theoplayer-control-padding` - The padding around a control. Defaults to `10px`.

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -118,6 +118,7 @@ export const FULL_WINDOW_ROOT_CLASS = 'theoplayer-ui-full-window';
  *   When {@link fluid} is set, this is automatically set to the video's natural aspect ratio.
  *   Set this to `none` (or any invalid `<length>`) to disable, for example when you want to use `--theoplayer-height` instead.
  * @cssproperty `--theoplayer-background` - The background color of the player. Defaults to `#000`.
+ * @cssproperty `--theoplayer-text-color` - The text color of a control. Defaults to `#fff`.
  * @cssproperty `--theoplayer-text-font-size` - The font size of any text inside a control. Defaults to `14px`.
  * @cssproperty `--theoplayer-control-height` - The height of a control. Defaults to `24px`.
  * @cssproperty `--theoplayer-control-padding` - The padding around a control. Defaults to `10px`.

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -126,12 +126,6 @@ export const FULL_WINDOW_ROOT_CLASS = 'theoplayer-ui-full-window';
  * @cssproperty `--theoplayer-control-backdrop-background` - The background shown behind all controls. Defaults to `transparent`.
  * @cssproperty `--theoplayer-menu-backdrop-background` - The background of the menu layer. Defaults to `rgba(0, 0, 0, 0.5)`.
  * @cssproperty `--theoplayer-menu-layer-padding` - Padding of the menu layer. Defaults to `10px`.
- * @cssproperty `--theoplayer-menu-offset-top` - Top offset of the menu layer. Defaults to `0`.
- * @cssproperty `--theoplayer-menu-offset-bottom` - Bottom offset of the menu layer. Defaults to `0`.
- * @cssproperty `--theoplayer-menu-margin-top` - Menu top margin (desktop). Defaults to `auto`.
- * @cssproperty `--theoplayer-menu-margin-bottom` - Menu bottom margin (desktop). Defaults to `0`.
- * @cssproperty `--theoplayer-menu-margin-left` - Menu left margin (desktop). Defaults to `auto`.
- * @cssproperty `--theoplayer-menu-margin-right` - Menu right margin (desktop). Defaults to `0`.
  * @cssproperty `--theoplayer-menu-min-width` - Minimum width of the menu (desktop). Defaults to `200px`.
  * @cssproperty `--theoplayer-error-background` - The background of the error layer shown when the player has a fatal error. Defaults to `rgba(0, 0, 0, 0.5)`.
  */

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -112,17 +112,17 @@ export const FULL_WINDOW_ROOT_CLASS = 'theoplayer-ui-full-window';
  *   (see {@link ErrorDisplay | `<theoplayer-error-display>`}).
  *
  * @cssproperty `--theoplayer-min-width` - The minimum width of the player. Defaults to `300px`.
- * @cssproperty `--theoplayer-height` - The height of the player. Defaults to unset (uses `--theoplayer-aspect-ratio`).
+ * @cssproperty `--theoplayer-height` - The height of the player. Defaults to `unset`.
+ *   Ignored when `--theoplayer-aspect-ratio` is set.
  * @cssproperty `--theoplayer-aspect-ratio` - The aspect ratio of the player. Defaults to `16 / 9`.
- *   Set to `none` (or any invalid `<length>`) to disable.
+ *   When {@link fluid} is set, this is automatically set to the video's natural aspect ratio.
+ *   Set this to `none` (or any invalid `<length>`) to disable, for example when you want to use `--theoplayer-height` instead.
  * @cssproperty `--theoplayer-background` - The background color of the player. Defaults to `#000`.
  * @cssproperty `--theoplayer-text-font-size` - The font size of any text inside a control. Defaults to `14px`.
  * @cssproperty `--theoplayer-control-height` - The height of a control. Defaults to `24px`.
  * @cssproperty `--theoplayer-control-padding` - The padding around a control. Defaults to `10px`.
  * @cssproperty `--theoplayer-video-border-radius` - The border radius of the `<video>` element. Defaults to `0`.
  * @cssproperty `--theoplayer-video-object-fit` - The `object-fit` of the `<video>` element. Defaults to `contain`.
- * @cssproperty `--theoplayer-video-width` - Used with `fluid` attribute to compute aspect ratio. Defaults to `16`.
- * @cssproperty `--theoplayer-video-height` - Used with `fluid` attribute to compute aspect ratio. Defaults to `9`.
  * @cssproperty `--theoplayer-control-backdrop-background` - The background shown behind all controls. Defaults to `transparent`.
  * @cssproperty `--theoplayer-menu-backdrop-background` - The background of the menu layer. Defaults to `rgba(0, 0, 0, 0.5)`.
  * @cssproperty `--theoplayer-menu-layer-padding` - Padding of the menu layer. Defaults to `10px`.

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -110,6 +110,27 @@ export const FULL_WINDOW_ROOT_CLASS = 'theoplayer-ui-full-window';
  * @slot `menu` - A slot for extra menus (see {@link Menu | `<theoplayer-menu>`}).
  * @slot `error` - A slot for an error display, to show when the player encounters a fatal error
  *   (see {@link ErrorDisplay | `<theoplayer-error-display>`}).
+ *
+ * @cssproperty `--theoplayer-min-width` - The minimum width of the player. Defaults to `300px`.
+ * @cssproperty `--theoplayer-height` - The height of the player. Defaults to unset (uses `--theoplayer-aspect-ratio`).
+ * @cssproperty `--theoplayer-aspect-ratio` - The aspect ratio of the player. Defaults to `16 / 9`.
+ *   Set to `none` (or any invalid `<length>`) to disable.
+ * @cssproperty `--theoplayer-background` - The background color of the player. Defaults to `#000`.
+ * @cssproperty `--theoplayer-video-border-radius` - The border radius of the `<video>` element. Defaults to `0`.
+ * @cssproperty `--theoplayer-video-object-fit` - The `object-fit` of the `<video>` element. Defaults to `contain`.
+ * @cssproperty `--theoplayer-video-width` - Used with `fluid` attribute to compute aspect ratio. Defaults to `16`.
+ * @cssproperty `--theoplayer-video-height` - Used with `fluid` attribute to compute aspect ratio. Defaults to `9`.
+ * @cssproperty `--theoplayer-control-backdrop-background` - The background shown behind all controls. Defaults to `transparent`.
+ * @cssproperty `--theoplayer-menu-backdrop-background` - The background of the menu layer. Defaults to `rgba(0, 0, 0, 0.5)`.
+ * @cssproperty `--theoplayer-menu-layer-padding` - Padding of the menu layer. Defaults to `10px`.
+ * @cssproperty `--theoplayer-menu-offset-top` - Top offset of the menu layer. Defaults to `0`.
+ * @cssproperty `--theoplayer-menu-offset-bottom` - Bottom offset of the menu layer. Defaults to `0`.
+ * @cssproperty `--theoplayer-menu-margin-top` - Menu top margin (desktop). Defaults to `auto`.
+ * @cssproperty `--theoplayer-menu-margin-bottom` - Menu bottom margin (desktop). Defaults to `0`.
+ * @cssproperty `--theoplayer-menu-margin-left` - Menu left margin (desktop). Defaults to `auto`.
+ * @cssproperty `--theoplayer-menu-margin-right` - Menu right margin (desktop). Defaults to `0`.
+ * @cssproperty `--theoplayer-menu-min-width` - Minimum width of the menu (desktop). Defaults to `200px`.
+ * @cssproperty `--theoplayer-error-background` - The background of the error layer shown when the player has a fatal error. Defaults to `rgba(0, 0, 0, 0.5)`.
  */
 @customElement('theoplayer-ui')
 export class UIContainer extends LitElement {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -116,6 +116,9 @@ export const FULL_WINDOW_ROOT_CLASS = 'theoplayer-ui-full-window';
  * @cssproperty `--theoplayer-aspect-ratio` - The aspect ratio of the player. Defaults to `16 / 9`.
  *   Set to `none` (or any invalid `<length>`) to disable.
  * @cssproperty `--theoplayer-background` - The background color of the player. Defaults to `#000`.
+ * @cssproperty `--theoplayer-text-font-size` - The font size of any text inside a control. Defaults to `14px`.
+ * @cssproperty `--theoplayer-control-height` - The height of a control. Defaults to `24px`.
+ * @cssproperty `--theoplayer-control-padding` - The padding around a control. Defaults to `10px`.
  * @cssproperty `--theoplayer-video-border-radius` - The border radius of the `<video>` element. Defaults to `0`.
  * @cssproperty `--theoplayer-video-object-fit` - The `object-fit` of the `<video>` element. Defaults to `contain`.
  * @cssproperty `--theoplayer-video-width` - Used with `fluid` attribute to compute aspect ratio. Defaults to `16`.

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -45,7 +45,8 @@ export function buttonTemplate(button: string, extraCss: string = ''): string {
  * @cssproperty `--theoplayer-button-checked-color` - The color of a toggled-on button. Defaults to `#000`.
  * @cssproperty `--theoplayer-button-disabled-text-color` - The text color of a disabled button. Defaults to `#ccc`.
  * @cssproperty `--theoplayer-before-first-play-display` - The CSS `display` of the button before first play.
- *   Set to `none` to hide the button until playback begins. Defaults to `inline-flex`.
+ *   The {@link UIContainer | `<theoplayer-ui>`} will set this to `none` to hide all buttons until playback begins,
+ *   after which this becomes `unset` and the button reverts back to its initial CSS `display`.
  */
 // Based on howto-toggle-button
 // https://github.com/GoogleChromeLabs/howto-components/blob/079d0fa34ff9038b26ea8883b1db5dd6b677d7ba/elements/howto-toggle-button/howto-toggle-button.js

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -24,6 +24,28 @@ export function buttonTemplate(button: string, extraCss: string = ''): string {
  * A basic button.
  *
  * @attribute `disabled` - Whether the button is disabled. When disabled, the button cannot be clicked.
+ *
+ * @cssproperty `--theoplayer-control-height` - The height of the button's control area (and default icon size). Defaults to `24px`.
+ * @cssproperty `--theoplayer-control-padding` - The padding around the button's content. Defaults to `10px`.
+ * @cssproperty `--theoplayer-control-background` - The background of the button. Defaults to `transparent`.
+ * @cssproperty `--theoplayer-control-hover-background` - The background of the button when hovered.
+ *   Defaults to `--theoplayer-control-background`.
+ * @cssproperty `--theoplayer-text-color` - The text color of the button. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-text-font-size` - The font size of the button's text. Defaults to `14px`.
+ * @cssproperty `--theoplayer-text-content-height` - The line-height of the button's text. Defaults to `--theoplayer-control-height`.
+ * @cssproperty `--theoplayer-icon-color` - The color of the button's icon. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-focus-ring-color` - The color of the focus ring around focused buttons. Defaults to `rgba(27, 127, 204, 0.9)`.
+ * @cssproperty `--theoplayer-button-text-color` - The text color of the button. Defaults to `--theoplayer-text-color`.
+ * @cssproperty `--theoplayer-button-icon-width` - The width of the button's icon. Defaults to `--theoplayer-control-height`.
+ * @cssproperty `--theoplayer-button-icon-height` - The height of the button's icon. Defaults to `--theoplayer-control-height`.
+ * @cssproperty `--theoplayer-button-icon-transition` - The CSS transition applied to the button's icon. Defaults to `none`.
+ * @cssproperty `--theoplayer-button-icon-shadow` - A drop-shadow applied to the icon. Defaults to `none`.
+ * @cssproperty `--theoplayer-button-hover-icon-shadow` - A drop-shadow applied to the icon on hover. Defaults to `0 0 4px rgba(255, 255, 255, 0.5)`.
+ * @cssproperty `--theoplayer-button-checked-background` - The background of a toggled-on button (e.g. mute, fullscreen). Defaults to `#fff`.
+ * @cssproperty `--theoplayer-button-checked-color` - The color of a toggled-on button. Defaults to `#000`.
+ * @cssproperty `--theoplayer-button-disabled-text-color` - The text color of a disabled button. Defaults to `#ccc`.
+ * @cssproperty `--theoplayer-before-first-play-display` - The CSS `display` of the button before first play.
+ *   Set to `none` to hide the button until playback begins. Defaults to `inline-flex`.
  */
 // Based on howto-toggle-button
 // https://github.com/GoogleChromeLabs/howto-components/blob/079d0fa34ff9038b26ea8883b1db5dd6b677d7ba/elements/howto-toggle-button/howto-toggle-button.js

--- a/src/components/ChromecastDisplay.ts
+++ b/src/components/ChromecastDisplay.ts
@@ -11,6 +11,17 @@ const CAST_EVENTS = ['statechange'] as const;
 
 /**
  * A control that displays the casting status while using Chromecast.
+ *
+ * @cssproperty `--theoplayer-chromecast-display-icon-color` - The color of the Chromecast icon. Defaults to `--theoplayer-icon-color`.
+ * @cssproperty `--theoplayer-chromecast-display-icon-width` - The width of the Chromecast icon. Defaults to `48px`.
+ * @cssproperty `--theoplayer-chromecast-display-icon-height` - The height of the Chromecast icon. Defaults to `48px`.
+ * @cssproperty `--theoplayer-chromecast-display-icon-gap` - The gap between the icon and the heading. Defaults to `10px`.
+ * @cssproperty `--theoplayer-chromecast-display-heading-color` - The color of the heading text. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-chromecast-display-heading-font-size` - The font size of the heading text. Defaults to `--theoplayer-text-font-size`.
+ * @cssproperty `--theoplayer-chromecast-display-heading-margin` - The margin around the heading text. Defaults to `0`.
+ * @cssproperty `--theoplayer-chromecast-display-receiver-color` - The color of the receiver name text. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-chromecast-display-receiver-font-size` - The font size of the receiver name text. Defaults to `calc(1.25 * var(--theoplayer-text-font-size, 14px))`.
+ * @cssproperty `--theoplayer-chromecast-display-receiver-margin` - The margin around the receiver name text. Defaults to `0`.
  */
 @customElement('theoplayer-chromecast-display')
 @stateReceiver(['player'])

--- a/src/components/ErrorDisplay.ts
+++ b/src/components/ErrorDisplay.ts
@@ -9,6 +9,17 @@ import { Attribute } from '../util/Attribute';
 
 /**
  * A screen that shows the details of a fatal player error.
+ *
+ * @cssproperty `--theoplayer-error-icon-color` - The color of the error icon. Defaults to `--theoplayer-icon-color`.
+ * @cssproperty `--theoplayer-error-icon-width` - The width of the error icon. Defaults to `48px`.
+ * @cssproperty `--theoplayer-error-icon-height` - The height of the error icon. Defaults to `48px`.
+ * @cssproperty `--theoplayer-error-icon-gap` - The gap between the error icon and the text. Defaults to `10px`.
+ * @cssproperty `--theoplayer-error-heading-color` - The text color of the error heading. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-error-heading-margin` - The margin around the error heading. Defaults to `0 0 10px`.
+ * @cssproperty `--theoplayer-error-message-color` - The text color of the error message. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-error-message-margin` - The margin around the error message. Defaults to `0`.
+ * @cssproperty `--theoplayer-error-min-width` - The minimum width of the error display. Defaults to `0`.
+ * @cssproperty `--theoplayer-error-max-width` - The maximum width of the error display. Defaults to `80%`.
  */
 @customElement('theoplayer-error-display')
 @stateReceiver(['error', 'fullscreen'])

--- a/src/components/LiveButton.ts
+++ b/src/components/LiveButton.ts
@@ -21,6 +21,9 @@ const DEFAULT_LIVE_THRESHOLD = 10;
  * @attribute `live-threshold` - The maximum distance (in seconds) from the live point that the player's current time
  *   can be for it to still be considered "at the live point". If unset, defaults to 10 seconds.
  * @attribute `live` (readonly) - Whether the player is considered to be playing at the live point.
+ *
+ * @cssproperty `--theoplayer-live-button-color` - The color of the live indicator when not at the live point. Defaults to `rgb(140, 140, 140)`.
+ * @cssproperty `--theoplayer-live-button-active-color` - The color of the live indicator when playing at the live point. Defaults to `red`.
  */
 @customElement('theoplayer-live-button')
 @stateReceiver(['player', 'streamType'])

--- a/src/components/LoadingIndicator.ts
+++ b/src/components/LoadingIndicator.ts
@@ -12,6 +12,11 @@ const PLAYER_EVENTS = ['readystatechange', 'play', 'pause', 'playing', 'seeking'
  * An indicator that shows whether the player is currently waiting for more data to resume playback.
  *
  * @attribute `loading` (readonly) - Whether the player is waiting for more data. If set, the indicator is shown.
+ *
+ * @cssproperty `--theoplayer-loading-delay` - The delay before the loading spinner is shown. Defaults to `0.5s`.
+ * @cssproperty `--theoplayer-loading-icon-color` - The color of the loading spinner. Defaults to `--theoplayer-icon-color`.
+ * @cssproperty `--theoplayer-loading-icon-width` - The width of the loading spinner. Defaults to `48px`.
+ * @cssproperty `--theoplayer-loading-icon-height` - The height of the loading spinner. Defaults to `--theoplayer-loading-icon-width`.
  */
 @customElement('theoplayer-loading-indicator')
 @stateReceiver(['player'])

--- a/src/components/Menu.ts
+++ b/src/components/Menu.ts
@@ -37,6 +37,11 @@ export function menuTemplate(heading: string, content: string, extraCss: string 
  * @attribute `menu-opened` (readonly) - Whether the menu is currently open.
  *
  * @slot `heading` - A slot for the menu's heading.
+ *
+ * @cssproperty `--theoplayer-menu-color` - The text color of menu items. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-menu-control-hover-background` - The background of a menu item when hovered. Defaults to `rgba(255, 255, 255, 0.3)`.
+ * @cssproperty `--theoplayer-menu-margin` - The margin around the menu. Defaults to `10px`.
+ * @cssproperty `--theoplayer-menu-max-width` - The maximum width of the menu. Defaults to `100%`.
  */
 @customElement('theoplayer-menu')
 export class Menu extends LitElement {

--- a/src/components/Menu.ts
+++ b/src/components/Menu.ts
@@ -41,6 +41,7 @@ export function menuTemplate(heading: string, content: string, extraCss: string 
  * @cssproperty `--theoplayer-menu-color` - The text color of menu items. Defaults to `#fff`.
  * @cssproperty `--theoplayer-menu-control-hover-background` - The background of a menu item when hovered. Defaults to `rgba(255, 255, 255, 0.3)`.
  * @cssproperty `--theoplayer-menu-margin` - The margin around the menu. Defaults to `10px`.
+ * @cssproperty `--theoplayer-menu-min-width` - The minimum width of the menu. Defaults to `80%`.
  * @cssproperty `--theoplayer-menu-max-width` - The maximum width of the menu. Defaults to `100%`.
  */
 @customElement('theoplayer-menu')

--- a/src/components/PlayButton.ts
+++ b/src/components/PlayButton.ts
@@ -17,6 +17,9 @@ const PLAYER_EVENTS = ['seeking', 'seeked', 'ended', 'emptied', 'sourcechange'] 
  *
  * @attribute `paused` (readonly) - Whether the player is paused. Reflects `ui.player.paused`.
  * @attribute `ended` (readonly) - Whether the player is ended. Reflects `ui.player.ended`.
+ *
+ * @cssproperty `--theoplayer-play-button-icon-color` - The icon color of the play button.
+ *   Overrides `--theoplayer-icon-color` for this button. Defaults to `unset`.
  */
 @customElement('theoplayer-play-button')
 @stateReceiver(['player'])

--- a/src/components/PreviewThumbnail.ts
+++ b/src/components/PreviewThumbnail.ts
@@ -19,6 +19,9 @@ const TRACK_EVENTS = ['addtrack', 'removetrack'] as const;
  * (e.g. `#xywh=180,80,60,40`), then the thumbnail is clipped to the rectangle defined by that fragment.
  *
  * If the stream does not contain thumbnails, then this display shows nothing.
+ *
+ * @cssproperty `--theoplayer-preview-thumbnail-background` - The background of the preview thumbnail container. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-preview-thumbnail-padding` - The padding around the preview thumbnail. Defaults to `2px`.
  */
 @customElement('theoplayer-preview-thumbnail')
 @stateReceiver(['player', 'previewTime'])

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -18,6 +18,33 @@ import { styleMap } from 'lit/directives/style-map.js';
  * @attribute `inert` - Whether the range is inert.
  *   When inert, the slider value cannot be changed, but the slider thumb is still visible.
  *
+ * @cssproperty `--theoplayer-range-bar-color` - The color of the filled portion of the range track. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-range-track-height` - The height of the range track. Defaults to `4px`.
+ * @cssproperty `--theoplayer-range-track-width` - The width of the range track. Defaults to `100%`.
+ * @cssproperty `--theoplayer-range-track-background` - The background of the unfilled portion of the track. Defaults to `rgba(255, 255, 255, 0.2)`.
+ * @cssproperty `--theoplayer-range-track-border` - The border of the track. Defaults to `none`.
+ * @cssproperty `--theoplayer-range-track-border-radius` - The border radius of the track. Defaults to `0`.
+ * @cssproperty `--theoplayer-range-track-box-shadow` - The box-shadow of the track. Defaults to `none`.
+ * @cssproperty `--theoplayer-range-track-transition` - The CSS transition applied to the track. Defaults to `none`.
+ * @cssproperty `--theoplayer-range-track-translate-x` - Horizontal translation of the track. Defaults to `0`.
+ * @cssproperty `--theoplayer-range-track-translate-y` - Vertical translation of the track. Defaults to `0`.
+ * @cssproperty `--theoplayer-range-track-outline` - The outline of the track.
+ * @cssproperty `--theoplayer-range-track-outline-offset` - The outline offset of the track.
+ * @cssproperty `--theoplayer-range-track-pointer-background` - The background of the hover/preview pointer indicator on the track. Defaults to `transparent`.
+ * @cssproperty `--theoplayer-range-track-pointer-border-right` - The right border of the pointer indicator. Defaults to `none`.
+ * @cssproperty `--theoplayer-range-thumb-width` - The width of the slider thumb. Defaults to `10px`.
+ * @cssproperty `--theoplayer-range-thumb-height` - The height of the slider thumb. Defaults to `10px`.
+ * @cssproperty `--theoplayer-range-thumb-background` - The background of the slider thumb. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-range-thumb-border` - The border of the slider thumb. Defaults to `none`.
+ * @cssproperty `--theoplayer-range-thumb-border-radius` - The border radius of the slider thumb. Defaults to `10px`.
+ * @cssproperty `--theoplayer-range-thumb-box-shadow` - The box-shadow of the slider thumb. Defaults to `1px 1px 1px transparent`.
+ * @cssproperty `--theoplayer-range-thumb-transition` - The CSS transition applied to the slider thumb. Defaults to `none`.
+ * @cssproperty `--theoplayer-range-thumb-transform` - The CSS transform applied to the slider thumb. Defaults to `none`.
+ * @cssproperty `--theoplayer-range-thumb-opacity` - The opacity of the slider thumb. Defaults to `1`.
+ * @cssproperty `--theoplayer-range-padding` - The padding around the range. Defaults to `--theoplayer-control-padding`.
+ * @cssproperty `--theoplayer-range-padding-left` - The left padding around the range. Defaults to `--theoplayer-range-padding`.
+ * @cssproperty `--theoplayer-range-padding-right` - The right padding around the range. Defaults to `--theoplayer-range-padding`.
+ *
  * @group Components
  */
 @stateReceiver(['deviceType'])

--- a/src/components/SeekButton.ts
+++ b/src/components/SeekButton.ts
@@ -14,6 +14,8 @@ const DEFAULT_SEEK_OFFSET = 10;
  * A button that seeks forward or backward by a fixed offset.
  *
  * @attribute `seek-offset` - The offset (in seconds) by which to seek forward (if positive) or backward (if negative).
+ *
+ * @cssproperty `--theoplayer-seek-button-font-size` - The font size of the offset number rendered inside the seek icon. Defaults to `calc(0.3 * --theoplayer-button-icon-height)`.
  */
 @customElement('theoplayer-seek-button')
 @stateReceiver(['player'])

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -37,6 +37,9 @@ const AD_MARKER_WIDTH = 1;
  * @slot `preview` - A slot holding a preview of the seek time, shown while hovering the seek bar.
  *   By default, this shows the {@link PreviewTimeDisplay | preview time} and
  *   the {@link PreviewThumbnail | preview thumbnail}.
+ *
+ * @cssproperty `--theoplayer-preview-text-shadow` - The text shadow applied to the preview box shown while hovering the seek bar.
+ *   Defaults to `0 0 4px rgba(0, 0, 0, 0.75)`.
  */
 @customElement('theoplayer-time-range')
 @stateReceiver(['player', 'streamType', 'deviceType'])

--- a/src/components/ads/AdDisplay.ts
+++ b/src/components/ads/AdDisplay.ts
@@ -12,6 +12,11 @@ const AD_EVENTS = ['adbreakbegin', 'adbreakend', 'adbreakchange', 'updateadbreak
 /**
  * A control that shows when an advertisement is playing,
  * and the number of the current ad in the ad break (if the break has multiple ads).
+ *
+ * @cssproperty `--theoplayer-ad-display-background` - The background of the ad display. Defaults to `#ffc50f`.
+ * @cssproperty `--theoplayer-ad-display-border-radius` - The border radius of the ad display. Defaults to `2px`.
+ * @cssproperty `--theoplayer-ad-display-padding` - The padding of the ad display. Defaults to `--theoplayer-control-padding`.
+ * @cssproperty `--theoplayer-ad-display-text-color` - The text color of the ad display. Defaults to `#000`.
  */
 @customElement('theoplayer-ad-display')
 @stateReceiver(['player'])

--- a/src/components/ads/AdSkipButton.ts
+++ b/src/components/ads/AdSkipButton.ts
@@ -16,6 +16,20 @@ const AD_EVENTS = ['adbegin', 'adend', 'adloaded', 'updatead', 'adskip'] as cons
 /**
  * A button that skips the current advertisement (if skippable).
  * If the ad cannot be skipped yet, it shows the remaining time until it can be skipped.
+ *
+ * @cssproperty `--theoplayer-ad-skip-background` - The background of the skip button. Defaults to `rgba(0, 0, 0, 0.7)`.
+ * @cssproperty `--theoplayer-ad-skip-color` - The text color of the skip button. Defaults to `#fff`.
+ * @cssproperty `--theoplayer-ad-skip-border` - The border of the skip button. Defaults to `1px solid rgba(255, 255, 255, 0.5)`.
+ * @cssproperty `--theoplayer-ad-skip-hover-background` - The background of the skip button when hovered. Defaults to `rgba(0, 0, 0, 0.9)`.
+ * @cssproperty `--theoplayer-ad-skip-hover-color` - The text color of the skip button when hovered. Defaults to `--theoplayer-ad-skip-color`.
+ * @cssproperty `--theoplayer-ad-skip-hover-border` - The border of the skip button when hovered. Defaults to `1px solid #fff`.
+ * @cssproperty `--theoplayer-ad-skip-countdown-background` - The background of the countdown shown before the ad is skippable. Defaults to `transparent`.
+ * @cssproperty `--theoplayer-ad-skip-countdown-color` - The text color of the countdown. Defaults to `--theoplayer-ad-skip-color`.
+ * @cssproperty `--theoplayer-ad-skip-countdown-border` - The border of the countdown. Defaults to `1px solid transparent`.
+ * @cssproperty `--theoplayer-ad-skip-font-size` - The font size of the skip button text. Defaults to `--theoplayer-text-font-size`.
+ * @cssproperty `--theoplayer-ad-skip-line-height` - The line height of the skip button text. Defaults to `--theoplayer-text-content-height`.
+ * @cssproperty `--theoplayer-ad-skip-icon-width` - The width of the skip button icon. Defaults to `--theoplayer-control-height`.
+ * @cssproperty `--theoplayer-ad-skip-icon-height` - The height of the skip button icon. Defaults to `--theoplayer-control-height`.
  */
 @customElement('theoplayer-ad-skip-button')
 @stateReceiver(['player'])

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -16,6 +16,11 @@
       "tagName": "@slot",
       "syntaxKind": "block",
       "allowMultiple": true
+    },
+    {
+      "tagName": "@cssproperty",
+      "syntaxKind": "block",
+      "allowMultiple": true
     }
   ]
 }

--- a/typedoc.config.mjs
+++ b/typedoc.config.mjs
@@ -8,7 +8,8 @@ export default {
         'typedoc-plugin-external-resolver',
         'typedoc-plugin-mdn-links',
         import.meta.resolve('./scripts/typedoc-lit-decorators.mts'),
-        import.meta.resolve('./scripts/typedoc-symbol-resolver.mts')
+        import.meta.resolve('./scripts/typedoc-symbol-resolver.mts'),
+        import.meta.resolve('./scripts/typedoc-collapsible-tags.mts')
     ],
     navigationLinks: {
         GitHub: 'https://github.com/THEOplayer/web-ui'


### PR DESCRIPTION
Each component can now document its custom CSS properties using `@cssproperty` tags. This should be compatible with [Custom Elements Manifest](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/#supported-jsdoc), in case we want to generate such a manifest in the future.

We added a custom TypeDoc plugin to render these tags as a table in the API documentation:
<img width="1375" height="515" alt="image" src="https://github.com/user-attachments/assets/70c371a1-e481-4e56-8c5e-0c6a9c81ddcb" />

Thanks to @ceyhun-o for kickstarting this effort!