### PR TITLE
Document attributes

### DIFF
--- a/scripts/typedoc-collapsible-tags.mts
+++ b/scripts/typedoc-collapsible-tags.mts
@@ -85,9 +85,7 @@ export function load(app: Application) {
         const tables: JSX.Element[] = [];
         for (const tag of collapsibleTags) {
             const commentTags = comment.blockTags.filter((t) => t.tag === tag.tag);
-            if (commentTags.length < 2) {
-                // Keep single entries as-is for simplicity.
-            } else {
+            if (commentTags.length > 0) {
                 // Take over rendering for these tags.
                 commentTags.forEach((t) => (t.skipRendering = true));
                 // Render them all as a single table.

--- a/scripts/typedoc-lit-decorators.mts
+++ b/scripts/typedoc-lit-decorators.mts
@@ -52,18 +52,19 @@ function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection
                 break;
             }
             case 'property': {
-                // Look for `attributeValue` in `@property({ attribute: attributeValue })`
+                // Look for `attributeName` in `@property({ attribute: attributeName })`
                 if (!ts.isObjectLiteralExpression(callArgument)) continue;
                 const propertyAttribute = callArgument.properties.find(
                     (p): p is ts.PropertyAssignment => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === 'attribute'
                 );
                 if (!propertyAttribute) continue;
                 const attributeInitializer = propertyAttribute.initializer;
-                let commentPart: typedoc.CommentDisplayPart;
+                let attributeNamePart: typedoc.CommentDisplayPart;
                 if (ts.isLiteralTypeLiteral(attributeInitializer)) {
                     if (ts.isStringLiteral(attributeInitializer)) {
                         // e.g. `@property({ attribute: "fluid" })`
-                        commentPart = { kind: 'text', text: attributeInitializer.text };
+                        const attributeName = attributeInitializer.text;
+                        attributeNamePart = { kind: 'text', text: `\`${attributeName}\`` };
                     } else if (attributeInitializer.kind === ts.SyntaxKind.FalseKeyword) {
                         // e.g. `@property({ attribute: false })`
                         continue;
@@ -73,13 +74,15 @@ function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection
                     }
                 } else if (ts.isPropertyAccessExpression(attributeInitializer)) {
                     // e.g. `@property({ attribute: Attribute.FLUID })`
-                    commentPart = { kind: 'inline-tag', tag: '@link', text: attributeInitializer.getText() };
+                    const attributeLink = attributeInitializer.getText();
+                    const attributeName = attributeInitializer.name.text.toLowerCase().replace(/_/g, '-');
+                    attributeNamePart = { kind: 'inline-tag', tag: '@link', text: `${attributeLink} | \`${attributeName}\`` };
                 } else {
                     console.warn(`Unexpected attribute in @property: ${attributeInitializer.getText()}`);
                     continue;
                 }
                 const comment = (refl.comment ??= new typedoc.Comment([]));
-                comment.blockTags.unshift(new typedoc.CommentTag(`@attribute`, [commentPart]));
+                comment.blockTags.unshift(new typedoc.CommentTag(`@attribute`, [attributeNamePart]));
                 break;
             }
         }

--- a/scripts/typedoc-lit-decorators.mts
+++ b/scripts/typedoc-lit-decorators.mts
@@ -87,8 +87,16 @@ function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection
                     console.warn(`Cannot find parent class of @property in reflection: ${refl.toString()}`);
                     continue;
                 }
+                const attributeComment = new typedoc.CommentTag(`@attribute`, [attributeNamePart]);
+                // Append summary.
+                if (refl.comment?.summary) {
+                    if (attributeComment.content.length < 2) {
+                        attributeComment.content.push({ kind: 'text', text: ' - ' });
+                    }
+                    attributeComment.content.push(...refl.comment.summary);
+                }
                 const comment = (parentClass.comment ??= new typedoc.Comment([]));
-                comment.blockTags.push(new typedoc.CommentTag(`@attribute`, [attributeNamePart]));
+                comment.blockTags.push(attributeComment);
                 break;
             }
         }

--- a/scripts/typedoc-lit-decorators.mts
+++ b/scripts/typedoc-lit-decorators.mts
@@ -87,7 +87,6 @@ function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection
                     console.warn(`Cannot find parent class of @property in reflection: ${refl.toString()}`);
                     continue;
                 }
-                const attributeComment = new typedoc.CommentTag(`@attribute`, [attributeNamePart]);
                 // Append summary.
                 let summary = refl.comment?.summary;
                 if (!summary && ts.isSetAccessorDeclaration(declaration)) {
@@ -99,10 +98,17 @@ function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection
                         summary = getterComment?.summary;
                     }
                 }
-                if (summary) {
-                    if (attributeComment.content.length < 2) {
-                        attributeComment.content.push({ kind: 'text', text: ' - ' });
+                if (!summary) {
+                    if (declaration.modifiers?.some((m) => ts.isModifier(m) && m.kind === ts.SyntaxKind.PrivateKeyword)) {
+                        // Private property without documentation, skip.
+                        continue;
+                    } else {
+                        console.warn(`Missing documentation for @property: ${refl.toString()}`);
                     }
+                }
+                const attributeComment = new typedoc.CommentTag(`@attribute`, [attributeNamePart]);
+                if (summary) {
+                    attributeComment.content.push({ kind: 'text', text: ' - ' });
                     attributeComment.content.push(...summary);
                 }
                 const comment = (parentClass.comment ??= new typedoc.Comment([]));

--- a/scripts/typedoc-lit-decorators.mts
+++ b/scripts/typedoc-lit-decorators.mts
@@ -81,10 +81,24 @@ function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection
                     console.warn(`Unexpected attribute in @property: ${attributeInitializer.getText()}`);
                     continue;
                 }
-                const comment = (refl.comment ??= new typedoc.Comment([]));
-                comment.blockTags.unshift(new typedoc.CommentTag(`@attribute`, [attributeNamePart]));
+                // Add as an `@attribute` comment on the parent class.
+                const parentClass = getParentClass(refl);
+                if (!parentClass) {
+                    console.warn(`Cannot find parent class of @property in reflection: ${refl.toString()}`);
+                    continue;
+                }
+                const comment = (parentClass.comment ??= new typedoc.Comment([]));
+                comment.blockTags.push(new typedoc.CommentTag(`@attribute`, [attributeNamePart]));
                 break;
             }
         }
     }
+}
+
+function getParentClass(refl: typedoc.Reflection): typedoc.Reflection | undefined {
+    let current: typedoc.Reflection | undefined = refl;
+    while (current !== undefined && current.kind !== typedoc.ReflectionKind.Class) {
+        current = current.parent;
+    }
+    return current;
 }

--- a/scripts/typedoc-lit-decorators.mts
+++ b/scripts/typedoc-lit-decorators.mts
@@ -88,15 +88,28 @@ function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection
                     (p): p is ts.PropertyAssignment => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && p.name.text === 'attribute'
                 );
                 if (!propertyAttribute) continue;
-                const attributeValue = propertyAttribute.initializer;
-                if (ts.isLiteralTypeLiteral(attributeValue)) {
-                    // e.g. `@property({ attribute: false })`
+                const attributeInitializer = propertyAttribute.initializer;
+                let commentPart: typedoc.CommentDisplayPart;
+                if (ts.isLiteralTypeLiteral(attributeInitializer)) {
+                    if (ts.isStringLiteral(attributeInitializer)) {
+                        // e.g. `@property({ attribute: "fluid" })`
+                        commentPart = { kind: 'text', text: attributeInitializer.text };
+                    } else if (attributeInitializer.kind === ts.SyntaxKind.FalseKeyword) {
+                        // e.g. `@property({ attribute: false })`
+                        continue;
+                    } else {
+                        console.warn(`Unexpected attribute in @property: ${attributeInitializer.getText()}`);
+                        continue;
+                    }
+                } else if (ts.isPropertyAccessExpression(attributeInitializer)) {
+                    // e.g. `@property({ attribute: Attribute.FLUID })`
+                    commentPart = { kind: 'inline-tag', tag: '@link', text: attributeInitializer.getText() };
+                } else {
+                    console.warn(`Unexpected attribute in @property: ${attributeInitializer.getText()}`);
                     continue;
                 }
                 const comment = (refl.comment ??= new typedoc.Comment([]));
-                comment.blockTags.unshift(
-                    new typedoc.CommentTag(`@attribute`, [{ kind: 'inline-tag', tag: '@link', text: attributeValue.getText() }])
-                );
+                comment.blockTags.unshift(new typedoc.CommentTag(`@attribute`, [commentPart]));
                 break;
             }
         }

--- a/scripts/typedoc-lit-decorators.mts
+++ b/scripts/typedoc-lit-decorators.mts
@@ -89,11 +89,21 @@ function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection
                 }
                 const attributeComment = new typedoc.CommentTag(`@attribute`, [attributeNamePart]);
                 // Append summary.
-                if (refl.comment?.summary) {
+                let summary = refl.comment?.summary;
+                if (!summary && ts.isSetAccessorDeclaration(declaration)) {
+                    // @property() must appear on the setter, but the documentation is usually on the getter.
+                    const symbol = context.getSymbolFromReflection(refl)!;
+                    const getter = symbol.declarations?.find(ts.isGetAccessorDeclaration);
+                    if (getter) {
+                        const getterComment = context.getNodeComment(getter, false);
+                        summary = getterComment?.summary;
+                    }
+                }
+                if (summary) {
                     if (attributeComment.content.length < 2) {
                         attributeComment.content.push({ kind: 'text', text: ' - ' });
                     }
-                    attributeComment.content.push(...refl.comment.summary);
+                    attributeComment.content.push(...summary);
                 }
                 const comment = (parentClass.comment ??= new typedoc.Comment([]));
                 comment.blockTags.push(attributeComment);

--- a/scripts/typedoc-lit-decorators.mts
+++ b/scripts/typedoc-lit-decorators.mts
@@ -6,7 +6,6 @@ import { TypeScript as ts } from 'typedoc';
  */
 export function load(app: typedoc.Application) {
     app.converter.on(typedoc.Converter.EVENT_CREATE_DECLARATION, onDeclaration);
-    app.converter.on(typedoc.Converter.EVENT_CREATE_SIGNATURE, onSignature);
 }
 
 function onDeclaration(context: typedoc.Context, refl: typedoc.DeclarationReflection) {
@@ -17,35 +16,6 @@ function onDeclaration(context: typedoc.Context, refl: typedoc.DeclarationReflec
     for (const declaration of declarations) {
         extractDecoratorInfo(context, refl, declaration);
     }
-}
-
-function onSignature(context: typedoc.Context, refl: typedoc.SignatureReflection) {
-    const symbol = context.getSymbolFromReflection(refl.parent);
-    if (!symbol) return;
-    const declarations = symbol.declarations;
-    if (!declarations) return;
-    let declaration: ts.Declaration | undefined;
-    switch (refl.kind) {
-        case typedoc.ReflectionKind.GetSignature:
-            declaration = declarations.find(ts.isGetAccessorDeclaration);
-            break;
-        case typedoc.ReflectionKind.SetSignature:
-            declaration = declarations.find(ts.isSetAccessorDeclaration);
-            break;
-        case typedoc.ReflectionKind.IndexSignature:
-            declaration = declarations.find(ts.isIndexSignatureDeclaration);
-            break;
-        case typedoc.ReflectionKind.CallSignature:
-            declaration = declarations.find(ts.isCallSignatureDeclaration);
-            break;
-        case typedoc.ReflectionKind.ConstructorSignature:
-            declaration = declarations.find(ts.isConstructSignatureDeclaration);
-            break;
-        default:
-            return;
-    }
-    if (!declaration) return;
-    extractDecoratorInfo(context, refl, declaration);
 }
 
 function extractDecoratorInfo(context: typedoc.Context, refl: typedoc.Reflection, declaration: ts.Declaration) {

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -13,7 +13,6 @@ import type { StreamType } from './util/StreamType';
 import { USER_IDLE_CHANGE_EVENT } from './events/UserIdleChangeEvent';
 import { READY_EVENT } from './events/ReadyEvent';
 import { ACCIDENTAL_CLICK_DELAY } from './util/Constants';
-import { toggleAttribute } from './util/CommonUtils';
 import { createCustomEvent } from './util/EventUtils';
 
 /**
@@ -252,9 +251,25 @@ export class DefaultUI extends LitElement {
     set deviceType(value: DeviceType) {
         if (this._deviceType === value) return;
         this._deviceType = value;
-        toggleAttribute(this, Attribute.MOBILE, value === 'mobile');
-        toggleAttribute(this, Attribute.TV, value === 'tv');
+        this.mobile = value === 'mobile';
+        this.tv = value === 'tv';
     }
+
+    /**
+     * Whether the user is on a mobile device.
+     *
+     * Equivalent to `deviceType == "mobile"`.
+     */
+    @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.MOBILE })
+    private accessor mobile: boolean = false;
+
+    /**
+     * Whether the user is on a TV device.
+     *
+     * Equivalent to `deviceType == "tv"`.
+     */
+    @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.TV })
+    private accessor tv: boolean = false;
 
     /**
      * The minimum length (in seconds) of a livestream's sliding window for the stream to be DVR

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -36,25 +36,6 @@ import { createCustomEvent } from './util/EventUtils';
  * For more extensive customizations, we recommend defining your own custom UI using
  * a {@link UIContainer | `<theoplayer-ui>`}.
  *
- * @attribute `configuration` - The THEOplayer {@link theoplayer!UIPlayerConfiguration | UIPlayerConfiguration}, as a JSON string.
- * @attribute `source` - The THEOplayer {@link theoplayer!SourceDescription | SourceDescription}, as a JSON string.
- * @attribute `fluid` - If set, the player automatically adjusts its height to fit the video's aspect ratio.
- * @attribute `muted` - If set, the player starts out as muted. Reflects `ui.player.muted`.
- * @attribute `autoplay` - If set, the player attempts to automatically start playing (if allowed).
- * @attribute `device-type` - The device type, either "desktop", "mobile" or "tv".
- *   Can be used in CSS to show/hide certain device-specific UI controls.
- * @attribute `mobile` - Whether the user is on a mobile device. Equivalent to `device-type == "mobile"`.
- * @attribute `tv` - Whether the user is on a TV device. Equivalent to `device-type == "tv"`.
- * @attribute `stream-type` - The stream type, either "vod", "live" or "dvr".
- *   Can be used to show/hide certain UI controls specific for livestreams, such as
- *   a {@link LiveButton | `<theoplayer-live-button>`}.
- *   If you know in advance that the source will be a livestream, you can set this attribute to avoid a screen flicker
- *   when the player switches between its VOD-specific and live-only controls.
- * @attribute `user-idle-timeout` - The timeout (in seconds) between when the user stops interacting with the UI,
- *   and when the user is considered to be "idle".
- * @attribute `dvr-threshold` - The minimum length (in seconds) of a livestream's sliding window for the stream to be DVR
- *   and its stream type to be set to "dvr".
- *
  * @slot `title` - A slot for the stream's title in the top control bar.
  * @slot `top-control-bar` - A slot for extra UI controls in the top control bar.
  * @slot `centered-chrome` - A slot to replace the controls in the center of the player,
@@ -143,9 +124,10 @@ export class DefaultUI extends LitElement {
     }
 
     /**
-     * The player configuration.
+     * The player's {@link theoplayer!UIPlayerConfiguration | configuration}.
      *
      * Used to create the underlying THEOplayer instance.
+     * When set as an attribute, this must be a JSON string.
      */
     get configuration(): UIPlayerConfiguration {
         return this._configuration;
@@ -171,7 +153,9 @@ export class DefaultUI extends LitElement {
     }
 
     /**
-     * The player's current source.
+     * The player's {@link theoplayer!SourceDescription | current source}.
+     *
+     * When set as an attribute, this must be a JSON string.
      */
     get source() {
         return this._uiRef.value ? this._uiRef.value.source : this._source;
@@ -201,6 +185,8 @@ export class DefaultUI extends LitElement {
 
     /**
      * Whether the player's audio is muted.
+     *
+     * This reflects `player.muted`.
      */
     @property({ reflect: true, type: Boolean, attribute: Attribute.MUTED })
     accessor muted: boolean = false;
@@ -216,6 +202,9 @@ export class DefaultUI extends LitElement {
      *
      * If you know in advance that the source will be a livestream, you can set this property to avoid a screen flicker
      * when the player switches between its VOD-specific and live-only controls.
+     *
+     * Can be used to show/hide certain UI controls specific for livestreams, such as
+     * a {@link LiveButton | `<theoplayer-live-button>`}.
      */
     @property({ reflect: true, type: String, attribute: Attribute.STREAM_TYPE })
     accessor streamType: StreamType = 'vod';
@@ -242,6 +231,8 @@ export class DefaultUI extends LitElement {
 
     /**
      * The device type, either "desktop", "mobile" or "tv".
+     *
+     * This attribute can be used in CSS to show/hide certain device-specific UI controls.
      */
     get deviceType(): DeviceType {
         return this._deviceType;

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -400,9 +400,8 @@ export class UIContainer extends LitElement {
     set deviceType(value: DeviceType) {
         if (this._deviceType === value) return;
         this._deviceType = value;
-
-        toggleAttribute(this, Attribute.MOBILE, value === 'mobile');
-        toggleAttribute(this, Attribute.TV, value === 'tv');
+        this.mobile = value === 'mobile';
+        this.tv = value === 'tv';
 
         window.removeEventListener('keydown', this._onTvKeyDown);
         if (value === 'tv') {
@@ -415,6 +414,22 @@ export class UIContainer extends LitElement {
             }
         }
     }
+
+    /**
+     * Whether the user is on a mobile device.
+     *
+     * Equivalent to `deviceType == "mobile"`.
+     */
+    @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.MOBILE })
+    private accessor mobile: boolean = false;
+
+    /**
+     * Whether the user is on a TV device.
+     *
+     * Equivalent to `deviceType == "tv"`.
+     */
+    @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.TV })
+    private accessor tv: boolean = false;
 
     /**
      * The stream type, either "vod", "live" or "dvr".

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -69,35 +69,6 @@ export const FULL_WINDOW_ROOT_CLASS = 'theoplayer-ui-full-window';
  *
  * The styling can be controlled using CSS custom properties (see below).
  *
- * @attribute `configuration` - The THEOplayer {@link theoplayer!UIPlayerConfiguration | UIPlayerConfiguration}, as a JSON string.
- * @attribute `source` - The THEOplayer {@link theoplayer!SourceDescription | SourceDescription}, as a JSON string.
- * @attribute `fluid` - If set, the player automatically adjusts its height to fit the video's aspect ratio.
- * @attribute `muted` - If set, the player starts out as muted. Reflects `ui.player.muted`.
- * @attribute `autoplay` - If set, the player attempts to automatically start playing (if allowed).
- * @attribute `device-type` - The device type, either "desktop", "mobile" or "tv".
- *   Can be used in CSS to show/hide certain device-specific UI controls.
- * @attribute `mobile` - Whether the user is on a mobile device. Equivalent to `device-type == "mobile"`.
- * @attribute `tv` - Whether the user is on a TV device. Equivalent to `device-type == "tv"`.
- * @attribute `stream-type` - The stream type, either "vod", "live" or "dvr".
- *   Can be used to show/hide certain UI controls specific for livestreams, such as
- *   a {@link LiveButton | `<theoplayer-live-button>`}.
- *   If you know in advance that the source will be a livestream, you can set this attribute to avoid a screen flicker
- *   when the player switches between its VOD-specific and live-only controls.
- * @attribute `user-idle` (readonly) - Whether the user is considered to be "idle".
- *   When the user is idle and the video is playing, all slotted UI elements will be hidden
- *   (unless they have the `no-auto-hide` attribute).
- * @attribute `user-idle-timeout` - The timeout (in seconds) between when the user stops interacting with the UI,
- *   and when the user is considered to be "idle".
- * @attribute `dvr-threshold` - The minimum length (in seconds) of a livestream's sliding window for the stream to be DVR
- *   and its stream type to be set to "dvr".
- * @attribute `paused` (readonly) - Whether the player is paused. Reflects `ui.player.paused`.
- * @attribute `ended` (readonly) - Whether the player is ended. Reflects `ui.player.ended`.
- * @attribute `casting` (readonly) - Whether the player is casting. Reflects `ui.player.cast.casting`.
- * @attribute `playing-ad` (readonly) - Whether the player is playing a linear ad. Reflects `ui.player.ads.playing`.
- * @attribute `has-error` (readonly) - Whether the player has encountered a fatal error.
- * @attribute `has-first-play` (readonly) - Whether the player has (previously) started playback for this stream.
- *   Can be used in CSS to show/hide certain initial controls, such as a poster image or a centered play button.
- *
  * @slot `(no` name, default slot) - A slot for controls at the bottom of the player.
  *   Can be used for controls such as a play button ({@link PlayButton | `<theoplayer-play-button>`}) or a seek bar
  *   ({@link TimeRange | `<theoplayer-time-range>`}).
@@ -323,6 +294,8 @@ export class UIContainer extends LitElement {
 
     /**
      * Whether the player is paused.
+     *
+     * This reflects `player.paused`
      */
     get paused(): boolean {
         return this._paused;
@@ -337,6 +310,8 @@ export class UIContainer extends LitElement {
 
     /**
      * Whether the player is ended.
+     *
+     * This reflects `player.ended`
      */
     get ended(): boolean {
         return this._ended;
@@ -349,6 +324,8 @@ export class UIContainer extends LitElement {
 
     /**
      * Whether the player is casting to a remote receiver.
+     *
+     * This reflects `player.cast.casting`
      */
     get casting(): boolean {
         return this._casting;
@@ -475,15 +452,32 @@ export class UIContainer extends LitElement {
         this._updateStreamType();
     }
 
+    /**
+     * Whether the player has (previously) started playback for this stream.
+     *
+     * Can be used in CSS to show/hide certain initial controls, such as a poster image or a centered play button.
+     */
     @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.HAS_FIRST_PLAY })
     private accessor _hasFirstPlay: boolean = false;
 
+    /**
+     * Whether the player is playing a linear ad.
+     *
+     * This reflects `player.ads.playing`.
+     */
     @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.PLAYING_AD })
     private accessor _isPlayingAd: boolean = false;
 
+    /**
+     * Whether the player has encountered a fatal error.
+     */
     @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.HAS_ERROR })
     private accessor _hasError: boolean = false;
 
+    /**
+     * Whether the player is in "full window" mode,
+     * as a fallback when the player cannot use the "native" fullscreen mode.
+     */
     @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.FULLWINDOW })
     private accessor _isFullWindow: boolean = false;
 
@@ -701,6 +695,9 @@ export class UIContainer extends LitElement {
         }
     }
 
+    /**
+     * Whether any {@link Menu | menu} is currently open.
+     */
     private get menuOpened_(): boolean {
         return this._menuOpened;
     }

--- a/src/components/ActiveQualityDisplay.ts
+++ b/src/components/ActiveQualityDisplay.ts
@@ -10,9 +10,15 @@ import { formatQualityLabel } from '../util/TrackUtils';
 @customElement('theoplayer-active-quality-display')
 @stateReceiver(['activeVideoQuality', 'targetVideoQualities'])
 export class ActiveQualityDisplay extends LitElement {
+    /**
+     * The currently active video quality.
+     */
     @property({ reflect: false, attribute: false })
     accessor activeVideoQuality: VideoQuality | undefined = undefined;
 
+    /**
+     * The list of target video qualities.
+     */
     @property({ reflect: false, attribute: false })
     accessor targetVideoQualities: VideoQuality[] | undefined = undefined;
 

--- a/src/components/Button.ts
+++ b/src/components/Button.ts
@@ -23,8 +23,6 @@ export function buttonTemplate(button: string, extraCss: string = ''): string {
 /**
  * A basic button.
  *
- * @attribute `disabled` - Whether the button is disabled. When disabled, the button cannot be clicked.
- *
  * @cssproperty `--theoplayer-control-height` - The height of the button's control area (and default icon size). Defaults to `24px`.
  * @cssproperty `--theoplayer-control-padding` - The padding around the button's content. Defaults to `10px`.
  * @cssproperty `--theoplayer-control-background` - The background of the button. Defaults to `transparent`.

--- a/src/components/ErrorDisplay.ts
+++ b/src/components/ErrorDisplay.ts
@@ -36,6 +36,9 @@ export class ErrorDisplay extends LitElement {
     @property({ reflect: false, attribute: false })
     accessor error: THEOplayerError | undefined;
 
+    /**
+     * Whether the player is in fullscreen mode.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.FULLSCREEN })
     accessor fullscreen: boolean = false;
 

--- a/src/components/FullscreenButton.ts
+++ b/src/components/FullscreenButton.ts
@@ -24,6 +24,9 @@ export class FullscreenButton extends Button {
         this._updateAriaLabel();
     }
 
+    /**
+     * Whether the player is in fullscreen mode.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.FULLSCREEN })
     accessor fullscreen: boolean = false;
 

--- a/src/components/GestureReceiver.ts
+++ b/src/components/GestureReceiver.ts
@@ -48,6 +48,9 @@ export class GestureReceiver extends LitElement {
         }
     }
 
+    /**
+     * The device type, either "desktop", "mobile" or "tv".
+     */
     @property({ reflect: false, attribute: false })
     accessor deviceType: DeviceType = 'desktop';
 

--- a/src/components/LanguageMenuButton.ts
+++ b/src/components/LanguageMenuButton.ts
@@ -15,8 +15,6 @@ const TRACK_EVENTS = ['addtrack', 'removetrack'] as const;
  * A menu button that opens a {@link LanguageMenu}.
  *
  * When there are no alternative audio languages or subtitles, this button automatically hides itself.
- *
- * @attribute `menu` - The ID of the language menu.
  */
 @customElement('theoplayer-language-menu-button')
 @stateReceiver(['player'])

--- a/src/components/LinkButton.ts
+++ b/src/components/LinkButton.ts
@@ -16,8 +16,6 @@ export function linkButtonTemplate(button: string, extraCss: string = ''): strin
 
 /**
  * A {@link Button | button} that opens a hyperlink.
- *
- * @attribute `disabled` - Whether the button is disabled. When disabled, the button cannot be clicked.
  */
 @customElement('theoplayer-link-button')
 export class LinkButton extends LitElement {

--- a/src/components/LiveButton.ts
+++ b/src/components/LiveButton.ts
@@ -18,10 +18,6 @@ const DEFAULT_LIVE_THRESHOLD = 10;
  * A button that shows whether the player is currently playing at the live point,
  * and seeks to the live point when clicked.
  *
- * @attribute `live-threshold` - The maximum distance (in seconds) from the live point that the player's current time
- *   can be for it to still be considered "at the live point". If unset, defaults to 10 seconds.
- * @attribute `live` (readonly) - Whether the player is considered to be playing at the live point.
- *
  * @cssproperty `--theoplayer-live-button-color` - The color of the live indicator when not at the live point. Defaults to `rgb(140, 140, 140)`.
  * @cssproperty `--theoplayer-live-button-active-color` - The color of the live indicator when playing at the live point. Defaults to `red`.
  */
@@ -47,6 +43,12 @@ export class LiveButton extends Button {
     @property({ reflect: true, type: String, attribute: Attribute.STREAM_TYPE })
     accessor streamType: StreamType = 'vod';
 
+    /**
+     * The maximum distance (in seconds) from the live point that the player's current time
+     * can be for it to still be considered "at the live point".
+     *
+     * If unset, defaults to 10 seconds.
+     */
     get liveThreshold(): number {
         return this._liveThreshold;
     }
@@ -57,6 +59,9 @@ export class LiveButton extends Button {
         this._updateLive();
     }
 
+    /**
+     * Whether the player is considered to be playing at the live point.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.LIVE })
     accessor live: boolean = false;
 

--- a/src/components/LiveButton.ts
+++ b/src/components/LiveButton.ts
@@ -37,9 +37,15 @@ export class LiveButton extends Button {
         }
     }
 
+    /**
+     * Whether the player is paused.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.PAUSED })
     accessor paused: boolean = false;
 
+    /**
+     * The stream type, either "vod", "live" or "dvr".
+     */
     @property({ reflect: true, type: String, attribute: Attribute.STREAM_TYPE })
     accessor streamType: StreamType = 'vod';
 

--- a/src/components/LoadingIndicator.ts
+++ b/src/components/LoadingIndicator.ts
@@ -11,8 +11,6 @@ const PLAYER_EVENTS = ['readystatechange', 'play', 'pause', 'playing', 'seeking'
 /**
  * An indicator that shows whether the player is currently waiting for more data to resume playback.
  *
- * @attribute `loading` (readonly) - Whether the player is waiting for more data. If set, the indicator is shown.
- *
  * @cssproperty `--theoplayer-loading-delay` - The delay before the loading spinner is shown. Defaults to `0.5s`.
  * @cssproperty `--theoplayer-loading-icon-color` - The color of the loading spinner. Defaults to `--theoplayer-icon-color`.
  * @cssproperty `--theoplayer-loading-icon-width` - The width of the loading spinner. Defaults to `48px`.
@@ -44,6 +42,9 @@ export class LoadingIndicator extends LitElement {
         }
     }
 
+    /**
+     * Whether the player is waiting for more data. If set, the indicator is shown.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.LOADING })
     accessor loading: boolean = false;
 

--- a/src/components/Menu.ts
+++ b/src/components/Menu.ts
@@ -32,10 +32,6 @@ export function menuTemplate(heading: string, content: string, extraCss: string 
  *
  * The menu has a heading at the top, with a {@link CloseMenuButton | close button} and a heading text.
  *
- * @attribute `menu-close-on-input` - Whether to automatically close the menu whenever one of its controls
- *   receives an input (e.g. when a radio button is clicked).
- * @attribute `menu-opened` (readonly) - Whether the menu is currently open.
- *
  * @slot `heading` - A slot for the menu's heading.
  *
  * @cssproperty `--theoplayer-menu-color` - The text color of menu items. Defaults to `#fff`.
@@ -85,6 +81,9 @@ export class Menu extends LitElement {
     @property({ reflect: true, type: Boolean, attribute: Attribute.MENU_CLOSE_ON_INPUT })
     accessor closeOnInput: boolean = false;
 
+    /**
+     * Whether the menu is currently open.
+     */
     private get menuOpened_(): boolean {
         return this._menuOpened;
     }

--- a/src/components/MenuButton.ts
+++ b/src/components/MenuButton.ts
@@ -6,8 +6,6 @@ import { customElement, property } from 'lit/decorators.js';
 
 /**
  * A menu button that opens a {@link Menu}.
- *
- * @attribute `menu` - The ID of the menu to open.
  */
 @customElement('theoplayer-menu-button')
 export class MenuButton extends Button {

--- a/src/components/MenuGroup.ts
+++ b/src/components/MenuGroup.ts
@@ -47,8 +47,6 @@ interface OpenMenuEntry {
  * This can contain multiple other menus, which can be opened with {@link openMenu}.
  * When a {@link MenuButton} in one menu opens another menu in this group, it is opened as a "submenu".
  * When a submenu is closed, the menu that originally opened it is shown again.
- *
- * @attribute `menu-opened` (readonly) - Whether any menu in the group is currently open.
  */
 @customElement('theoplayer-menu-group')
 export class MenuGroup extends LitElement {
@@ -71,6 +69,9 @@ export class MenuGroup extends LitElement {
 
     private _menuOpened: boolean = false;
 
+    /**
+     * Whether any menu in the group is currently open.
+     */
     private get menuOpened_(): boolean {
         return this._menuOpened;
     }

--- a/src/components/MuteButton.ts
+++ b/src/components/MuteButton.ts
@@ -16,9 +16,6 @@ const PLAYER_EVENTS = ['volumechange'] as const;
 
 /**
  * A button that toggles whether audio is muted or not.
- *
- * @attribute `volume-level` (readonly) - The volume level of the player.
- *   Can be "off" (muted), "low" (volume < 50%) or "high" (volume >= 50%).
  */
 @customElement('theoplayer-mute-button')
 @stateReceiver(['player'])
@@ -35,6 +32,8 @@ export class MuteButton extends Button {
 
     /**
      * The volume level of the player.
+     *
+     * Can be "off" (muted), "low" (volume < 50%) or "high" (volume >= 50%).
      */
     @property({ reflect: true, state: true, type: String, attribute: Attribute.VOLUME_LEVEL })
     accessor volumeLevel: VolumeLevel = 'off';

--- a/src/components/PlayButton.ts
+++ b/src/components/PlayButton.ts
@@ -15,9 +15,6 @@ const PLAYER_EVENTS = ['seeking', 'seeked', 'ended', 'emptied', 'sourcechange'] 
 /**
  * A button that toggles whether the player is playing or paused.
  *
- * @attribute `paused` (readonly) - Whether the player is paused. Reflects `ui.player.paused`.
- * @attribute `ended` (readonly) - Whether the player is ended. Reflects `ui.player.ended`.
- *
  * @cssproperty `--theoplayer-play-button-icon-color` - The icon color of the play button.
  *   Overrides `--theoplayer-icon-color` for this button. Defaults to `unset`.
  */
@@ -34,9 +31,19 @@ export class PlayButton extends Button {
         this._updateAriaLabel();
     }
 
+    /**
+     * Whether the player is paused.
+     *
+     * This reflects `player.paused`.
+     */
     @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.PAUSED })
     accessor paused: boolean = false;
 
+    /**
+     * Whether the player is ended.
+     *
+     * This reflects `player.ended`.
+     */
     @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.ENDED })
     accessor ended: boolean = false;
 

--- a/src/components/PreviewTimeDisplay.ts
+++ b/src/components/PreviewTimeDisplay.ts
@@ -39,6 +39,9 @@ export class PreviewTimeDisplay extends LitElement {
     @property({ reflect: true, type: Boolean, attribute: Attribute.REMAINING_WHEN_LIVE })
     accessor remainingWhenLive: boolean = false;
 
+    /**
+     * The stream type, either "vod", "live" or "dvr".
+     */
     @property({ reflect: true, type: String, attribute: Attribute.STREAM_TYPE })
     accessor streamType: StreamType = 'vod';
 

--- a/src/components/PreviewTimeDisplay.ts
+++ b/src/components/PreviewTimeDisplay.ts
@@ -11,10 +11,6 @@ const PLAYER_EVENTS = ['timeupdate', 'seeking', 'seeked', 'durationchange'] as c
 
 /**
  * A display that shows the current preview time of a {@link TimeRange | `<theoplayer-time-range>`}.
- *
- * @attribute `remaining` - If set, shows the remaining time of the stream.
- * @attribute `remaining-when-live` - If set, and the stream is a livestream, shows the remaining time
- *   (until the live point) of the stream.
  */
 @customElement('theoplayer-preview-time-display')
 @stateReceiver(['player', 'previewTime', 'streamType'])
@@ -31,9 +27,15 @@ export class PreviewTimeDisplay extends LitElement {
     @state()
     accessor previewTime: number = NaN;
 
+    /**
+     * If set, shows the remaining time of the stream.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.REMAINING })
     accessor remaining: boolean = false;
 
+    /**
+     * If set, and the stream is a livestream, shows the remaining time (until the live point) of the stream.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.REMAINING_WHEN_LIVE })
     accessor remainingWhenLive: boolean = false;
 

--- a/src/components/RadioGroup.ts
+++ b/src/components/RadioGroup.ts
@@ -60,6 +60,9 @@ export class RadioGroup extends LitElement {
         return root;
     }
 
+    /**
+     * The device type, either "desktop", "mobile" or "tv".
+     */
     @property({ reflect: true, type: String, attribute: Attribute.DEVICE_TYPE })
     accessor deviceType: DeviceType = 'desktop';
 

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -13,11 +13,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 /**
  * A slider to select a value from a range.
  *
- * @attribute `disabled` - Whether the range is disabled.
- *   When disabled, the slider value cannot be changed, and the slider thumb is hidden.
- * @attribute `inert` - Whether the range is inert.
- *   When inert, the slider value cannot be changed, but the slider thumb is still visible.
- *
  * @cssproperty `--theoplayer-range-bar-color` - The color of the filled portion of the range track. Defaults to `#fff`.
  * @cssproperty `--theoplayer-range-track-height` - The height of the range track. Defaults to `4px`.
  * @cssproperty `--theoplayer-range-track-width` - The width of the range track. Defaults to `100%`.

--- a/src/components/Range.ts
+++ b/src/components/Range.ts
@@ -193,6 +193,9 @@ export abstract class Range extends LitElement {
     })
     accessor step: number | 'any' = 'any';
 
+    /**
+     * The device type, either "desktop", "mobile" or "tv".
+     */
     @property({ reflect: true, type: String, attribute: Attribute.DEVICE_TYPE })
     accessor deviceType: DeviceType = 'desktop';
 

--- a/src/components/SeekButton.ts
+++ b/src/components/SeekButton.ts
@@ -13,8 +13,6 @@ const DEFAULT_SEEK_OFFSET = 10;
 /**
  * A button that seeks forward or backward by a fixed offset.
  *
- * @attribute `seek-offset` - The offset (in seconds) by which to seek forward (if positive) or backward (if negative).
- *
  * @cssproperty `--theoplayer-seek-button-font-size` - The font size of the offset number rendered inside the seek icon. Defaults to `calc(0.3 * --theoplayer-button-icon-height)`.
  */
 @customElement('theoplayer-seek-button')

--- a/src/components/TextTrackStyleDisplay.ts
+++ b/src/components/TextTrackStyleDisplay.ts
@@ -11,8 +11,6 @@ import { knownColors, knownEdgeStyles, knownFontFamilies } from '../util/TextTra
 /**
  * A control that displays the value of a single text track style option
  * in a human-readable format.
- *
- * @attribute `property` - The property name of the text track style option. One of {@link TextTrackStyleOption}.
  */
 @customElement('theoplayer-text-track-style-display')
 @stateReceiver(['player'])
@@ -23,6 +21,8 @@ export class TextTrackStyleDisplay extends LitElement {
 
     /**
      * The property name of the text track style option.
+     *
+     * One of {@link TextTrackStyleOption}.
      */
     get property(): TextTrackStyleOption {
         return this._property;

--- a/src/components/TextTrackStyleRadioGroup.ts
+++ b/src/components/TextTrackStyleRadioGroup.ts
@@ -28,7 +28,6 @@ export type TextTrackStyleOption = keyof TextTrackStyleMap;
  * A radio group that shows a list of values for a text track style option,
  * from which the user can choose a desired value.
  *
- * @attribute `property` - The property name of the text track style option. One of {@link TextTrackStyleOption}.
  * @slot {@link RadioButton} - The possible options for the text track style option.
  *   For example: `<theoplayer-radio-button value="#ff0000">Red</theoplayer-radio-button>`
  */
@@ -53,6 +52,8 @@ export class TextTrackStyleRadioGroup extends LitElement {
 
     /**
      * The property name of the text track style option.
+     *
+     * One of {@link TextTrackStyleOption}.
      */
     get property(): TextTrackStyleOption {
         return this._property;

--- a/src/components/TimeDisplay.ts
+++ b/src/components/TimeDisplay.ts
@@ -73,6 +73,9 @@ export class TimeDisplay extends LitElement {
     @property({ reflect: true, type: Boolean, attribute: Attribute.SHOW_DURATION })
     accessor showDuration: boolean = false;
 
+    /**
+     * The stream type, either "vod", "live" or "dvr".
+     */
     @property({ reflect: true, type: String, attribute: Attribute.STREAM_TYPE })
     accessor streamType: StreamType = 'vod';
 

--- a/src/components/TimeDisplay.ts
+++ b/src/components/TimeDisplay.ts
@@ -13,11 +13,6 @@ const DEFAULT_MISSING_TIME_PHRASE = 'video not loaded, unknown time';
 
 /**
  * A control that displays the current time of the stream.
- *
- * @attribute `show-duration` - If set, also shows the duration of the stream.
- * @attribute `remaining` - If set, shows the remaining time of the stream. Not compatible with `show-duration`.
- * @attribute `remaining-when-live` - If set, and the stream is a livestream, shows the remaining time
- *   (until the live point) of the stream.
  */
 @customElement('theoplayer-time-display')
 @stateReceiver(['player', 'streamType'])
@@ -59,12 +54,22 @@ export class TimeDisplay extends LitElement {
             this._player.addEventListener(PLAYER_EVENTS, this._updateFromPlayer);
         }
     }
+
+    /**
+     * If set, shows the remaining time of the stream. Not compatible with {@link showDuration}.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.REMAINING })
     accessor remaining: boolean = false;
 
+    /**
+     * If set, and the stream is a livestream, shows the remaining time (until the live point) of the stream.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.REMAINING_WHEN_LIVE })
     accessor remainingWhenLive: boolean = false;
 
+    /**
+     * If set, also shows the duration of the stream.
+     */
     @property({ reflect: true, type: Boolean, attribute: Attribute.SHOW_DURATION })
     accessor showDuration: boolean = false;
 

--- a/src/components/TimeRange.ts
+++ b/src/components/TimeRange.ts
@@ -118,6 +118,9 @@ export class TimeRange extends Range {
         this._ads?.addEventListener(AD_EVENTS, this._onAdChange);
     }
 
+    /**
+     * The stream type, either "vod", "live" or "dvr".
+     */
     get streamType(): StreamType {
         return this._streamType;
     }
@@ -128,6 +131,9 @@ export class TimeRange extends Range {
         this.updateDisabled_();
     }
 
+    /**
+     * Whether to show markers for advertisements on the seek bar.
+     */
     get showAdMarkers(): boolean {
         return this._showAdMarkers;
     }

--- a/src/components/TrackRadioGroup.ts
+++ b/src/components/TrackRadioGroup.ts
@@ -15,10 +15,6 @@ export type TrackType = 'audio' | 'video' | 'subtitles';
 /**
  * A radio group that shows a list of media or text tracks,
  * from which the user can choose an active track.
- *
- * @attribute `track-type` - The track type of the available tracks. Can be "audio", "video" or "subtitles".
- * @attribute `show-off` - If set, shows an "off" button to disable all tracks.
- *   Can only be used with the "subtitles" track type.
  */
 @customElement('theoplayer-track-radio-group')
 @stateReceiver(['player'])
@@ -33,6 +29,8 @@ export class TrackRadioGroup extends LitElement {
 
     /**
      * The track type of the available tracks.
+     *
+     * Can be "audio", "video" or "subtitles".
      */
     get trackType(): TrackType {
         return this._trackType;

--- a/src/components/ads/AdClickThroughButton.ts
+++ b/src/components/ads/AdClickThroughButton.ts
@@ -33,6 +33,9 @@ export class AdClickThroughButton extends LinkButton {
         }
     }
 
+    /**
+     * The click-through URL of the advertisement.
+     */
     get clickThrough(): string | null {
         return this._clickThrough;
     }


### PR DESCRIPTION
We now re-use the documentation of class properties (with a `@property` decorator) for the associated attribute. This way, we no longer need a separate `@attribute` tag in the component's documentation.