### PR TITLE
Set tap highlight color transparent on iOS Safari

### DIFF
--- a/.changeset/brown-pandas-juggle.md
+++ b/.changeset/brown-pandas-juggle.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/web-ui': patch
+---
+
+Fixed a brief tap highlight appearing behind button icons on iOS Safari.

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -6,6 +6,7 @@
     vertical-align: middle;
     pointer-events: auto;
     user-select: none;
+    -webkit-tap-highlight-color: transparent;
 
     background: var(--theoplayer-control-background, transparent);
     color: var(--theoplayer-button-text-color, var(--theoplayer-text-color, #fff));


### PR DESCRIPTION
This fixes the "black square" that appears when pressing icons on iOS Safari: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/-webkit-tap-highlight-color

As far as I can see this doesn't conflict with any other default styling in place.

Before:

https://github.com/user-attachments/assets/f7907ff4-2e85-40e1-aaba-71253bb827e0

After:

https://github.com/user-attachments/assets/6f4d25d4-cfe0-423e-9a65-e462a81c2a13