### PR TITLE
Fix volume loop on casting

### DIFF
--- a/.changeset/quiet-lobsters-sneeze.md
+++ b/.changeset/quiet-lobsters-sneeze.md
@@ -2,4 +2,4 @@
 '@theoplayer/web-ui': patch
 ---
 
-Fixed infinite SET_VOLUME loop when casting to receivers that don't support master volume control
+Fixed infinite `SET_VOLUME` loop when casting to receivers that don't support master volume control.

--- a/.changeset/quiet-lobsters-sneeze.md
+++ b/.changeset/quiet-lobsters-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/web-ui': patch
+---
+
+Fixed infinite SET_VOLUME loop when casting to receivers that don't support master volume control

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -254,7 +254,7 @@ export class UIContainer extends LitElement {
     @property({ reflect: true, type: Boolean, attribute: Attribute.MUTED })
     set muted(value: boolean) {
         this._muted = value;
-        if (this._player) {
+        if (this._player && this._player.muted !== value) {
             this._player.muted = value;
         }
     }

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -269,7 +269,7 @@ export class UIContainer extends LitElement {
     @property({ reflect: true, type: Boolean, attribute: Attribute.AUTOPLAY })
     set autoplay(value: boolean) {
         this._autoplay = value;
-        if (this._player) {
+        if (this._player && this._player.autoplay !== value) {
             this._player.autoplay = value;
         }
     }
@@ -538,8 +538,12 @@ export class UIContainer extends LitElement {
             this._player.source = this._source;
             this._source = undefined;
         }
-        this._player.muted = this.muted;
-        this._player.autoplay = this.autoplay;
+        if (this._player.muted !== this.muted) {
+            this._player.muted = this.muted;
+        }
+        if (this._player.autoplay !== this.autoplay) {
+            this._player.autoplay = this.autoplay;
+        }
 
         this._updateAspectRatio();
         this._updateError();

--- a/src/components/PlaybackRateRadioGroup.ts
+++ b/src/components/PlaybackRateRadioGroup.ts
@@ -47,7 +47,7 @@ export class PlaybackRateRadioGroup extends LitElement {
             return;
         }
         this._value = value;
-        if (this._player !== undefined) {
+        if (this._player !== undefined && this._player.playbackRate !== value) {
             this._player.playbackRate = value;
         }
         const radioGroup = this._radioGroupRef.value;


### PR DESCRIPTION
UIContainer.muted setter unconditionally writes back to player.muted on every volumechange event, creating a feedback loop when the cast receiver cannot converge on the sender's expected volume state.
This PR prevents a feedback loop during casting by guarding against redundant writes.