### PR TITLE
OPTI-3200: Update text track margins on time

### DIFF
--- a/.changeset/six-plums-relax.md
+++ b/.changeset/six-plums-relax.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/web-ui': patch
+---
+
+Fixed an issue where the subtitles were briefly overlapping the control bar.

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -600,11 +600,9 @@ export class UIContainer extends LitElement {
         }
     }
 
-    protected override updated(changedProperties: PropertyValues): void {
+    protected override updated(): void {
         // Update the text track margins after the relevant attributes have been reflected to the DOM.
-        if (changedProperties.has('paused') || changedProperties.has('casting') || changedProperties.has('userIdle')) {
-            this._updateTextTrackMargins();
-        }
+        this._updateTextTrackMargins();
     }
 
     disconnectedCallback(): void {

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1,4 +1,4 @@
-import { html, type HTMLTemplateResult, LitElement } from 'lit';
+import { html, type HTMLTemplateResult, LitElement, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { createRef, ref, type Ref } from 'lit/directives/ref.js';
 import * as shadyCss from '@webcomponents/shadycss';
@@ -328,7 +328,6 @@ export class UIContainer extends LitElement {
     @property({ reflect: true, type: Boolean, attribute: Attribute.PAUSED })
     private set paused(value: boolean) {
         this._paused = value;
-        this._updateTextTrackMargins();
         this.updateUserIdle_();
     }
 
@@ -358,7 +357,6 @@ export class UIContainer extends LitElement {
     @property({ reflect: true, type: Boolean, attribute: Attribute.CASTING })
     private set casting(value: boolean) {
         this._casting = value;
-        this._updateTextTrackMargins();
         this.updateUserIdle_();
     }
 
@@ -373,7 +371,6 @@ export class UIContainer extends LitElement {
     private set userIdle(value: boolean) {
         if (this._userIdle === value) return;
         this._userIdle = value;
-        this._updateTextTrackMargins();
         this.dispatchEvent(createCustomEvent(USER_IDLE_CHANGE_EVENT));
     }
 
@@ -600,6 +597,13 @@ export class UIContainer extends LitElement {
 
         if (this._playerRef.value) {
             void forEachStateReceiverElement(this, this._playerRef.value, this.registerStateReceiver_);
+        }
+    }
+
+    protected override updated(changedProperties: PropertyValues): void {
+        // Update the text track margins after the relevant attributes have been reflected to the DOM.
+        if (changedProperties.has('paused') || changedProperties.has('casting') || changedProperties.has('userIdle')) {
+            this._updateTextTrackMargins();
         }
     }
 


### PR DESCRIPTION
The player pushes subtitles up when the control bar appears so they don't overlap. To do that, we check whether the control bar is visible and measure its height.

The bug: that check was too early, before the player's UI had actually updated DOM.

The fix: move the check to run after the UI updates. Now it sees the current state and reacts right away, subtitles move up the moment the bar appears, and drop back when it's gone.

This was a regression on the Lit rewrite on 2.0, latest 1.X didn't have this issue.