### PR TITLE
Localize error message in `<theoplayer-error-display>`

### DIFF
--- a/.changeset/tall-weeks-guess.md
+++ b/.changeset/tall-weeks-guess.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/web-ui': patch
+---
+
+Added support for localizing the error message in `<theoplayer-error-display>`.

--- a/src/components/ErrorDisplay.ts
+++ b/src/components/ErrorDisplay.ts
@@ -48,10 +48,12 @@ export class ErrorDisplay extends LitElement {
 
     protected override render() {
         const locale = getLocale(this.lang);
+        const error = this.error;
+        const message = error ? locale.errorMessage(error) : '';
         return html`<div part="icon"><slot name="icon">${unsafeSVG(errorIcon)}</slot></div>
             <div part="text">
                 <h1 part="heading"><slot name="heading">${locale.errorHeading}</slot></h1>
-                <p part="message"><slot name="message">${this.error?.message ?? ''}</slot></p>
+                <p part="message"><slot name="message">${message}</slot></p>
             </div>
             <div part="fullscreen-controls">
                 <slot name="fullscreen-controls"><theoplayer-fullscreen-button></theoplayer-fullscreen-button></slot>

--- a/src/i18n/Locale.ts
+++ b/src/i18n/Locale.ts
@@ -2,7 +2,7 @@ import { durationFormatterForLocale } from './DurationFormatter';
 import { percentageFormatterForLocale } from './PercentageFormatter';
 import { bandwidthFormatterForLocale } from './BandwidthFormatter';
 import { languageFormatterForLocale } from './LanguageFormatter';
-import type { EdgeStyle } from 'theoplayer/chromeless';
+import type { EdgeStyle, THEOplayerError } from 'theoplayer/chromeless';
 import type {
     ActiveQualityDisplay,
     AdClickThroughButton,
@@ -344,6 +344,14 @@ export interface Locale {
      */
     errorHeading: string;
     /**
+     * The error message for an {@link ErrorDisplay}.
+     *
+     * This is optional. If not provided, the original `error.message` is used.
+     *
+     * @param error A player error.
+     */
+    errorMessage(error: THEOplayerError): string;
+    /**
      * The {@link HTMLElement.ariaLabel | `aria-label`} for a {@link BadNetworkModeButton}.
      */
     openBadNetworkModeMenuAria: string;
@@ -543,6 +551,7 @@ export const defaultLocale: Locale = {
     highQualityLabel: 'High Quality',
     lowQualityLabel: 'Low Quality',
     errorHeading: 'An error occurred',
+    errorMessage: (error) => error.message,
     openBadNetworkModeMenuAria: 'open bad network mode menu',
     formatDuration: durationFormatterForLocale(defaultLocaleName, 'long'),
     formatNarrowDuration: durationFormatterForLocale(defaultLocaleName, 'narrow'),


### PR DESCRIPTION
By default, the error message is always shown in English. This PR allows a `Locale` to provide its own localized error messages, e.g. by `switch`ing on `error.code` or `error.category`.