### PR TITLE
Improve support for TV remote controls

### DIFF
--- a/.changeset/hip-geese-happen.md
+++ b/.changeset/hip-geese-happen.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/web-ui': minor
+---
+
+Improved support for TV remote controls.

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -411,7 +411,10 @@ export class DefaultUI extends LitElement {
                         mobile-only
                         ad-hidden
                     ></theoplayer-seek-button>
-                    <theoplayer-play-button part="center-play-button play-button center-button"></theoplayer-play-button>
+                    <theoplayer-play-button
+                        part="center-play-button play-button center-button"
+                        ?tv-focus=${!this.hasFirstPlay}
+                    ></theoplayer-play-button>
                     <theoplayer-seek-button
                         part="seek-forward-button seek-button center-button"
                         seek-offset="10"
@@ -437,7 +440,7 @@ export class DefaultUI extends LitElement {
                     <theoplayer-time-range
                         part="time-range"
                         show-ad-markers
-                        tv-focus
+                        ?tv-focus=${this.hasFirstPlay}
                         .inert=${this._timeRangeInert}
                         class="theoplayer-ad-control"
                         style=${styleMap({

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -99,6 +99,7 @@ export class DefaultUI extends LitElement {
     private _userIdleTimeout: number | undefined = undefined;
     private _deviceType: DeviceType = 'desktop';
     private _dvrThreshold: number = DEFAULT_DVR_THRESHOLD;
+    private _hasFirstPlay: boolean = false;
 
     @queryAssignedNodes({ slot: 'title', flatten: true })
     private accessor titleSlotNodes!: Array<Node>;
@@ -305,7 +306,12 @@ export class DefaultUI extends LitElement {
      * Can be used to show/hide certain initial controls, such as a poster image or a centered play button.
      */
     get hasFirstPlay(): boolean {
-        return this._uiRef.value ? this._uiRef.value.hasFirstPlay : false;
+        return this._hasFirstPlay;
+    }
+
+    @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.HAS_FIRST_PLAY })
+    private set hasFirstPlay(hasFirstPlay: boolean) {
+        this._hasFirstPlay = hasFirstPlay;
     }
 
     @state()
@@ -327,10 +333,14 @@ export class DefaultUI extends LitElement {
         }
 
         this._onTitleSlotChange();
+
+        this._updateFirstPlay();
+        this._addPlayerListeners();
     }
 
     disconnectedCallback(): void {
         clearTimeout(this._timeRangeInertTimeout);
+        this._removePlayerListeners();
     }
 
     protected override firstUpdated() {
@@ -340,9 +350,37 @@ export class DefaultUI extends LitElement {
         }
     }
 
+    private _addPlayerListeners() {
+        const player = this._uiRef.value?.player;
+        if (player === undefined) {
+            return;
+        }
+
+        this._removePlayerListeners();
+        player.addEventListener(['play', 'sourcechange'], this._updateFirstPlay);
+    }
+
+    private _removePlayerListeners() {
+        const player = this._uiRef.value?.player;
+        if (player === undefined) {
+            return;
+        }
+
+        player.removeEventListener(['play', 'sourcechange'], this._updateFirstPlay);
+    }
+
     protected _onUiReady(): void {
+        this._updateFirstPlay();
+        this._addPlayerListeners();
+
         this.dispatchEvent(createCustomEvent(READY_EVENT));
     }
+
+    private readonly _updateFirstPlay = () => {
+        if (this._uiRef.value) {
+            this.hasFirstPlay = this._uiRef.value.hasFirstPlay;
+        }
+    };
 
     private readonly _updateStreamType = () => {
         if (this._uiRef.value) {

--- a/src/DefaultUI.ts
+++ b/src/DefaultUI.ts
@@ -296,6 +296,18 @@ export class DefaultUI extends LitElement {
         this._dvrThreshold = isNaN(value) ? 0 : value;
     }
 
+    /**
+     * Whether the player has (previously) started playback for this stream.
+     *
+     * This is set to `true` on the first play,
+     * and is reset to `false` when changing to a different (non-autoplaying) source.
+     *
+     * Can be used to show/hide certain initial controls, such as a poster image or a centered play button.
+     */
+    get hasFirstPlay(): boolean {
+        return this._uiRef.value ? this._uiRef.value.hasFirstPlay : false;
+    }
+
     @state()
     private accessor _hasTitle: boolean = false;
 

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -35,7 +35,7 @@ import { getTargetQualities } from './util/TrackUtils';
 import { MenuGroup } from './components/MenuGroup';
 import type { DeviceType } from './util/DeviceType';
 import { getFocusedChild, navigateByArrowKey } from './util/KeyboardNavigation';
-import { isArrowKey, isBackKey, KeyCode } from './util/KeyCode';
+import { isArrowKey, isBackKey, isPauseKey, isPlayKey, KeyCode } from './util/KeyCode';
 import { READY_EVENT } from './events/ReadyEvent';
 import { addGlobalStyles } from './Global';
 import { ACCIDENTAL_CLICK_DELAY } from './util/Constants';
@@ -1157,6 +1157,20 @@ export class UIContainer extends LitElement {
             this.setUserIdle_();
             return;
         }
+
+        // Handle playback buttons on TV remote.
+        if (this._player !== undefined) {
+            if (isPlayKey(event)) {
+                event.preventDefault();
+                this._player.play();
+                return;
+            } else if (isPauseKey(event)) {
+                event.preventDefault();
+                this._player.pause();
+                return;
+            }
+        }
+
         const tvFocusChildren = getTvFocusChildren(this);
         const focusableChildren = getFocusableChildren(this);
         let focusedChild = getFocusedChild();

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1185,11 +1185,12 @@ export class UIContainer extends LitElement {
             }
         }
 
+        // First button press should only make the UI visible.
         if (this.isUserIdle_()) {
-            // First button press should only make the UI visible
             return;
         }
 
+        // Navigate by arrow keys.
         if (isArrowKey(event.keyCode) && navigateByArrowKey(this, focusableChildren, event.keyCode)) {
             event.preventDefault();
             event.stopPropagation();

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1189,12 +1189,8 @@ export class UIContainer extends LitElement {
             // First button press should only make the UI visible
             return;
         }
-        if (event.keyCode === KeyCode.ENTER) {
-            if (focusedChild !== null) {
-                event.preventDefault();
-                focusedChild.click();
-            }
-        } else if (isArrowKey(event.keyCode) && navigateByArrowKey(this, focusableChildren, event.keyCode)) {
+
+        if (isArrowKey(event.keyCode) && navigateByArrowKey(this, focusableChildren, event.keyCode)) {
             event.preventDefault();
             event.stopPropagation();
         }

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1172,11 +1172,9 @@ export class UIContainer extends LitElement {
         }
 
         // Try to focus the first focusable child.
-        const tvFocusChildren = getTvFocusChildren(this);
-        const focusableChildren = getFocusableChildren(this);
         let focusedChild = getFocusedChild();
         if (!focusedChild) {
-            const children = tvFocusChildren ?? focusableChildren;
+            const children = getTvFocusChildren(this) ?? getFocusableChildren(this);
             if (children.length > 0) {
                 focusedChild = children[0];
                 event.preventDefault();
@@ -1191,7 +1189,7 @@ export class UIContainer extends LitElement {
         }
 
         // Navigate by arrow keys.
-        if (isArrowKey(event.keyCode) && navigateByArrowKey(this, focusableChildren, event.keyCode)) {
+        if (isArrowKey(event.keyCode) && focusedChild && navigateByArrowKey(this, focusedChild, getFocusableChildren(this), event.keyCode)) {
             event.preventDefault();
             event.stopPropagation();
         }

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1171,14 +1171,17 @@ export class UIContainer extends LitElement {
             }
         }
 
+        // Try to focus the first focusable child.
         const tvFocusChildren = getTvFocusChildren(this);
         const focusableChildren = getFocusableChildren(this);
         let focusedChild = getFocusedChild();
         if (!focusedChild) {
             const children = tvFocusChildren ?? focusableChildren;
             if (children.length > 0) {
-                children[0].focus();
                 focusedChild = children[0];
+                event.preventDefault();
+                focusedChild.focus();
+                return;
             }
         }
 

--- a/src/UIContainer.ts
+++ b/src/UIContainer.ts
@@ -1,4 +1,4 @@
-import { html, type HTMLTemplateResult, LitElement, type PropertyValues } from 'lit';
+import { html, type HTMLTemplateResult, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { createRef, ref, type Ref } from 'lit/directives/ref.js';
 import * as shadyCss from '@webcomponents/shadycss';
@@ -151,6 +151,7 @@ export class UIContainer extends LitElement {
     private _ended: boolean = false;
     private _casting: boolean = false;
     private _dvrThreshold: number = DEFAULT_DVR_THRESHOLD;
+    private _hasFirstPlay: boolean = false;
     private _previewTime: number = NaN;
     private _activeVideoTrack: MediaTrack | undefined = undefined;
 
@@ -476,10 +477,19 @@ export class UIContainer extends LitElement {
     /**
      * Whether the player has (previously) started playback for this stream.
      *
-     * Can be used in CSS to show/hide certain initial controls, such as a poster image or a centered play button.
+     * This is set to `true` on the first play,
+     * and is reset to `false` when changing to a different (non-autoplaying) source.
+     *
+     * Can be used to show/hide certain initial controls, such as a poster image or a centered play button.
      */
+    get hasFirstPlay(): boolean {
+        return this._hasFirstPlay;
+    }
+
     @property({ reflect: true, state: true, type: Boolean, attribute: Attribute.HAS_FIRST_PLAY })
-    private accessor _hasFirstPlay: boolean = false;
+    private set hasFirstPlay(hasFirstPlay: boolean) {
+        this._hasFirstPlay = hasFirstPlay;
+    }
 
     /**
      * Whether the player is playing a linear ad.
@@ -968,7 +978,7 @@ export class UIContainer extends LitElement {
     };
 
     private readonly _onPlay = (): void => {
-        this._hasFirstPlay = true;
+        this.hasFirstPlay = true;
         this.paused = false;
         this._updateEnded();
     };
@@ -1096,7 +1106,7 @@ export class UIContainer extends LitElement {
 
     private readonly _onSourceChange = (): void => {
         this.closeMenu_();
-        this._hasFirstPlay = this._player !== undefined && !this._player.paused;
+        this.hasFirstPlay = this._player !== undefined && !this._player.paused;
     };
 
     private isUserIdle_(): boolean {

--- a/src/components/RadioGroup.ts
+++ b/src/components/RadioGroup.ts
@@ -112,7 +112,8 @@ export class RadioGroup extends LitElement {
 
     private readonly _onKeyDown = (event: KeyboardEvent) => {
         if (this.deviceType === 'tv' && isArrowKey(event.keyCode)) {
-            if (navigateByArrowKey(this, this._radioButtons, event.keyCode)) {
+            const focusedRadioButton = this.focusedRadioButton;
+            if (focusedRadioButton && navigateByArrowKey(this, focusedRadioButton, this._radioButtons, event.keyCode)) {
                 event.preventDefault();
                 event.stopPropagation();
             }

--- a/src/util/KeyCode.ts
+++ b/src/util/KeyCode.ts
@@ -12,7 +12,13 @@ export enum KeyCode {
     // https://suite.st/docs/faq/tv-specific-keys-in-browser/
     BACK_SAMSUNG = 88,
     BACK_WEBOS = 461,
-    BACK_TIZEN = 10009
+    BACK_TIZEN = 10009,
+    // https://forum.webostv.developer.lge.com/t/keycodes-for-lg-webos-standard-and-magic-remote/239/4
+    PAUSE_WEBOS = 411,
+    PLAY_WEBOS = 415,
+    FAST_FORWARD_WEBOS = 417,
+    REWIND_WEBOS = 412,
+    STOP_WEBOS = 413
 }
 
 export type ArrowKeyCode = KeyCode.LEFT | KeyCode.UP | KeyCode.RIGHT | KeyCode.DOWN;
@@ -29,4 +35,12 @@ export function isBackKey(keyCode: number): keyCode is BackKeyCode {
 
 export function isActivationKey(keyCode: number): keyCode is ActivationKeyCode {
     return keyCode === KeyCode.ENTER || keyCode === KeyCode.SPACE;
+}
+
+export function isPlayKey(event: KeyboardEvent): boolean {
+    return event.code === 'Play' || event.keyCode === KeyCode.PLAY_WEBOS;
+}
+
+export function isPauseKey(event: KeyboardEvent): boolean {
+    return event.code === 'Pause' || event.keyCode === KeyCode.PAUSE_WEBOS;
 }

--- a/src/util/KeyboardNavigation.ts
+++ b/src/util/KeyboardNavigation.ts
@@ -10,11 +10,7 @@ export function getFocusedChild(): HTMLElement | null {
     return focusedChild;
 }
 
-export function navigateByArrowKey(container: HTMLElement, children: HTMLElement[], key: ArrowKeyCode): boolean {
-    const focusedChild = getFocusedChild();
-    if (focusedChild === null) {
-        return false;
-    }
+export function navigateByArrowKey(container: HTMLElement, focusedChild: HTMLElement, children: HTMLElement[], key: ArrowKeyCode): boolean {
     const containerRect = Rectangle.fromRect(container.getBoundingClientRect()).snapToPixels();
     const focusedRect = Rectangle.fromRect(focusedChild.getBoundingClientRect()).snapToPixels();
     const childrenWithRects = children


### PR DESCRIPTION
When using the default UI on a smart TV, the initial focus wasn't properly set to the center play button. This fixes that.

We now also support more remote control buttons for play/pause.