### PR TITLE
Add new examples

### DIFF
--- a/docs/components/Example.tsx
+++ b/docs/components/Example.tsx
@@ -59,7 +59,7 @@ export default function Example({ hideSource, hideDeviceType, languages, ref, ..
         <>
             <iframe ref={iframeRef} {...props}></iframe>
             {showOptions && (
-                <p>
+                <div>
                     {languages && (
                         <div>
                             <label style={{ userSelect: 'none' }}>
@@ -101,7 +101,7 @@ export default function Example({ hideSource, hideDeviceType, languages, ref, ..
                             </label>
                         </div>
                     )}
-                </p>
+                </div>
             )}
         </>
     );

--- a/docs/components/Example.tsx
+++ b/docs/components/Example.tsx
@@ -8,10 +8,12 @@ export interface Controller {
 export interface Props extends ComponentPropsWithoutRef<'iframe'> {
     hideSource?: boolean;
     hideDeviceType?: boolean;
+    // This is for the language selector on the Localization example.
+    languages?: Record<string, string>;
     ref?: Ref<Controller> | undefined;
 }
 
-export default function Example({ hideSource, hideDeviceType, ref, ...props }: Props): JSX.Element {
+export default function Example({ hideSource, hideDeviceType, languages, ref, ...props }: Props): JSX.Element {
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     useImperativeHandle(ref, () => {
         return {
@@ -23,6 +25,16 @@ export default function Example({ hideSource, hideDeviceType, ref, ...props }: P
 
     const [sourceName, setSourceName] = useState<SourceName>('bigBuckBunny');
     const [deviceType, setDeviceType] = useState('');
+    const [language, setLanguage] = useState(languages ? Object.keys(languages)[0] : '');
+
+    // Send message to <iframe> when language changes
+    useEffect(() => {
+        if (!languages) return;
+        iframeRef.current?.contentWindow?.postMessage({
+            type: 'language',
+            language: language
+        });
+    }, [iframeRef.current, language, languages]);
 
     // Send message to <iframe> when source changes
     useEffect(() => {
@@ -42,12 +54,26 @@ export default function Example({ hideSource, hideDeviceType, ref, ...props }: P
         });
     }, [iframeRef.current, deviceType, hideDeviceType]);
 
-    const showOptions = !hideSource || !hideDeviceType;
+    const showOptions = !hideSource || !hideDeviceType || !!languages;
     return (
         <>
             <iframe ref={iframeRef} {...props}></iframe>
             {showOptions && (
                 <p>
+                    {languages && (
+                        <div>
+                            <label style={{ userSelect: 'none' }}>
+                                Language:{' '}
+                                <select value={language} onChange={(e) => setLanguage(e.target.value)}>
+                                    {Object.entries(languages).map(([value, label]) => (
+                                        <option key={value} value={value}>
+                                            {label}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+                        </div>
+                    )}
                     {!hideSource && (
                         <div>
                             <label style={{ userSelect: 'none' }}>

--- a/docs/components/Example.tsx
+++ b/docs/components/Example.tsx
@@ -8,7 +8,6 @@ export interface Controller {
 export interface Props extends ComponentPropsWithoutRef<'iframe'> {
     hideSource?: boolean;
     hideDeviceType?: boolean;
-    // This is for the language selector on the Localization example.
     languages?: Record<string, string>;
     ref?: Ref<Controller> | undefined;
 }

--- a/docs/examples/custom-ui/_category_.json
+++ b/docs/examples/custom-ui/_category_.json
@@ -2,5 +2,6 @@
   "label": "Custom UI",
   "position": 20,
   "collapsible": true,
-  "collapsed": true
+  "collapsed": true,
+  "description": "Samples demonstrating how to implement a custom UI and modify different components."
 }

--- a/docs/examples/custom-ui/_category_.json
+++ b/docs/examples/custom-ui/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Custom UI",
+  "position": 20,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/examples/custom-ui/custom-play-button.mdx
+++ b/docs/examples/custom-ui/custom-play-button.mdx
@@ -1,0 +1,71 @@
+---
+sidebar_position: 6
+sidebar_custom_props: { 'icon': '⏯️' }
+slug: /web/examples/custom-play-button
+---
+
+# Custom play button
+
+import Example from '../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/web/custom-play-button/demo.html')} hideDeviceType />
+
+This sample demonstrates a custom, animated play button.
+
+<details>
+    <summary>Code</summary>
+    ```html showLineNumbers
+    <style>
+        .big-play {
+            color: #fff;
+            background: rgba(124, 58, 237, 0.45);
+            backdrop-filter: blur(6px);
+            border-radius: 50%;
+            padding: 32px;
+            transition: transform 0.4s ease;
+        }
+        .big-play svg {
+            width: 64px;
+            height: 64px;
+        }
+        /* Only pulse while hovered. */
+        .big-play:hover {
+            animation: pulse 3s ease-in-out infinite;
+        }
+        @keyframes pulse {
+            0%, 100% { transform: scale(1); }
+            50% { transform: scale(1.06); }
+        }
+    </style>
+
+    <theoplayer-ui
+        configuration='{"libraryLocation":"/path/to/theoplayer/","license":"your_theoplayer_license"}'
+        source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"}}'
+    >
+        <div slot="centered-chrome">
+            <theoplayer-play-button class="big-play">
+                <svg slot="play-icon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor"><path d="M8 5v14l11-7z"></path></svg>
+                <svg slot="pause-icon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor"><path d="M6 5h4v14H6zM14 5h4v14h-4z"></path></svg>
+            </theoplayer-play-button>
+        </div>
+        <div class="bottom-chrome">
+            <theoplayer-control-bar>
+                <theoplayer-time-range></theoplayer-time-range>
+            </theoplayer-control-bar>
+            <theoplayer-control-bar>
+                <theoplayer-play-button></theoplayer-play-button>
+                <theoplayer-mute-button></theoplayer-mute-button>
+                <theoplayer-volume-range></theoplayer-volume-range>
+                <theoplayer-time-display show-duration></theoplayer-time-display>
+                <theoplayer-fullscreen-button></theoplayer-fullscreen-button>
+            </theoplayer-control-bar>
+        </div>
+        <theoplayer-error-display slot="error"></theoplayer-error-display>
+    </theoplayer-ui>
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/web/custom-play-button/demo.html)
+
+</details>

--- a/docs/examples/custom-ui/example.mdx
+++ b/docs/examples/custom-ui/example.mdx
@@ -1,15 +1,19 @@
 ---
-sidebar_position: 20
+sidebar_position: 1
 sidebar_custom_props: { 'icon': '▶️' }
+slug: /web/examples/custom-ui
+sidebar_label: Custom styling
 ---
 
 # Custom UI
 
-import Example from '../components/Example';
+import Example from '../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './shared.module.css';
+import styles from '../shared.module.css';
 
 <Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/web/custom-ui/demo.html')}></Example>
+
+This sample demonstrates a basic custom UI.
 
 <details>
     <summary>Code</summary>

--- a/docs/examples/custom-ui/modern.mdx
+++ b/docs/examples/custom-ui/modern.mdx
@@ -1,0 +1,58 @@
+---
+sidebar_position: 5
+sidebar_custom_props: { 'icon': '✨' }
+slug: /web/examples/modern
+---
+
+# Modern UI
+
+import Example from '../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/web/modern/demo.html')} hideDeviceType />
+
+This sample demonstrates a modern, streaming-service style custom UI: a centered playback "pill" with rewind, play/pause and forward, a full-width seek bar, and rounded translucent control clusters.
+
+<details>
+    <summary>Code</summary>
+    ```html showLineNumbers
+    <theoplayer-ui
+        configuration='{"libraryLocation":"/path/to/theoplayer/","license":"your_theoplayer_license"}'
+        source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"}}'
+    >
+        <div slot="centered-chrome">
+            <div class="pill center-pill">
+                <theoplayer-seek-button seek-offset="-10"></theoplayer-seek-button>
+                <theoplayer-play-button></theoplayer-play-button>
+                <theoplayer-seek-button seek-offset="10"></theoplayer-seek-button>
+            </div>
+        </div>
+        <div class="bottom-chrome">
+            <theoplayer-control-bar>
+                <theoplayer-time-range></theoplayer-time-range>
+            </theoplayer-control-bar>
+            <div class="bottom-row">
+                <span class="pill">
+                    <theoplayer-play-button></theoplayer-play-button>
+                    <span class="volume">
+                        <theoplayer-mute-button></theoplayer-mute-button>
+                        <theoplayer-volume-range></theoplayer-volume-range>
+                    </span>
+                    <theoplayer-time-display show-duration></theoplayer-time-display>
+                </span>
+                <span class="spacer"></span>
+                <span class="pill">
+                    <theoplayer-language-menu-button menu="language-menu"></theoplayer-language-menu-button>
+                    <theoplayer-fullscreen-button></theoplayer-fullscreen-button>
+                </span>
+            </div>
+        </div>
+        <theoplayer-language-menu id="language-menu" slot="menu" hidden></theoplayer-language-menu>
+        <theoplayer-error-display slot="error"></theoplayer-error-display>
+    </theoplayer-ui>
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/web/modern/demo.html)
+
+</details>

--- a/docs/examples/custom-ui/nitflex.mdx
+++ b/docs/examples/custom-ui/nitflex.mdx
@@ -1,13 +1,15 @@
 ---
-sidebar_position: 22
+sidebar_position: 2
 sidebar_custom_props: { 'icon': '📺' }
+slug: /web/examples/nitflex
+sidebar_label: Nitflex theme
 ---
 
 # Custom UI: Nitflex theme
 
-import Example from '../components/Example';
+import Example from '../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './shared.module.css';
+import styles from '../shared.module.css';
 
 <Example className={styles.player} hideDeviceType src={useBaseUrl('/open-video-ui/v2/examples/web/nitflex/demo.html')}></Example>
 

--- a/docs/examples/custom-ui/portrait.mdx
+++ b/docs/examples/custom-ui/portrait.mdx
@@ -1,13 +1,15 @@
 ---
-sidebar_position: 21
+sidebar_position: 3
 sidebar_custom_props: { 'icon': '📱' }
+slug: /web/examples/portrait
+sidebar_label: Portrait theme
 ---
 
 # Custom UI: Portrait theme
 
-import Example from '../components/Example';
+import Example from '../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './shared.module.css';
+import styles from '../shared.module.css';
 
 <Example className={styles.portraitPlayer} hideSource hideDeviceType src={useBaseUrl('/open-video-ui/v2/examples/web/portrait/demo.html')}></Example>
 

--- a/docs/examples/custom-ui/text-tracks.mdx
+++ b/docs/examples/custom-ui/text-tracks.mdx
@@ -1,0 +1,81 @@
+---
+sidebar_position: 4
+sidebar_custom_props: { 'icon': '💬' }
+slug: /web/examples/text-tracks
+---
+
+# Text tracks and subtitles
+
+import Example from '../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/web/text-tracks/demo.html')} hideSource hideDeviceType />
+
+This example demonstrates the text track components for subtitle selection and styling.
+
+The settings menu contains four submenus:
+
+- **Subtitles**: the idiomatic `<theoplayer-track-radio-group track-type="subtitles" show-off>`, which composes `<theoplayer-text-track-off-radio-button>` and `<theoplayer-text-track-radio-button>` for you.
+- **Subtitles (custom)**: the same picker built manually from `<theoplayer-text-track-off-radio-button>` and `<theoplayer-text-track-radio-button>`.
+- **Subtitle appearance**: the pre-built `<theoplayer-text-track-style-menu>`, which composes `<theoplayer-text-track-style-display>`, `<theoplayer-text-track-style-radio-group>` and `<theoplayer-text-track-style-reset-button>`.
+- **Font color (custom)**: a single style option built manually from `<theoplayer-text-track-style-radio-group>` and `<theoplayer-text-track-style-reset-button>`.
+
+<details>
+    <summary>Code</summary>
+    ```html showLineNumbers
+    <theoplayer-ui
+        configuration='{"libraryLocation":"/path/to/theoplayer/","license":"your_theoplayer_license"}'
+        source='{"sources":{"src":"https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8"},"metadata":{"title":"Elephant&apos;s Dream"}}'
+    >
+        <theoplayer-control-bar>
+            <theoplayer-play-button></theoplayer-play-button>
+            <theoplayer-mute-button></theoplayer-mute-button>
+            <theoplayer-volume-range></theoplayer-volume-range>
+            <theoplayer-time-display show-duration></theoplayer-time-display>
+            <theoplayer-language-menu-button menu="language-menu"></theoplayer-language-menu-button>
+            <theoplayer-menu-button menu="settings-menu">CC</theoplayer-menu-button>
+            <theoplayer-fullscreen-button></theoplayer-fullscreen-button>
+        </theoplayer-control-bar>
+
+        <theoplayer-language-menu id="language-menu" slot="menu" hidden></theoplayer-language-menu>
+
+        <theoplayer-menu-group id="settings-menu" slot="menu" hidden>
+            <theoplayer-menu>
+                <span slot="heading">Subtitles &amp; captions</span>
+                <theoplayer-menu-button menu="subtitle-menu"><span>Select</span></theoplayer-menu-button>
+                <theoplayer-menu-button menu="subtitle-style-menu">
+                    <theoplayer-text-track-style-display property="fontColor"></theoplayer-text-track-style-display>
+                </theoplayer-menu-button>
+            </theoplayer-menu>
+
+            <!-- Idiomatic subtitle picker (composes TextTrackOffRadioButton + TextTrackRadioButton). -->
+            <theoplayer-menu id="subtitle-menu" menu-close-on-input hidden>
+                <span slot="heading">Subtitles</span>
+                <theoplayer-track-radio-group track-type="subtitles" show-off></theoplayer-track-radio-group>
+            </theoplayer-menu>
+
+            <!-- Pre-built subtitle style menu. -->
+            <theoplayer-text-track-style-menu id="subtitle-style-menu" menu-close-on-input hidden>
+                <span slot="heading">Subtitle appearance</span>
+            </theoplayer-text-track-style-menu>
+
+            <!-- Manual font color submenu (TextTrackStyleRadioGroup + TextTrackStyleResetButton). -->
+            <theoplayer-menu id="font-color-menu" menu-close-on-input hidden>
+                <theoplayer-text-track-style-reset-button slot="heading"></theoplayer-text-track-style-reset-button>
+                <span slot="heading">Font color (custom)</span>
+                <theoplayer-text-track-style-radio-group property="fontColor">
+                    <theoplayer-radio-button value="">Default</theoplayer-radio-button>
+                    <theoplayer-radio-button value="rgb(255,255,0)">Yellow</theoplayer-radio-button>
+                    <theoplayer-radio-button value="rgb(0,255,255)">Cyan</theoplayer-radio-button>
+                </theoplayer-text-track-style-radio-group>
+            </theoplayer-menu>
+        </theoplayer-menu-group>
+
+        <theoplayer-error-display slot="error"></theoplayer-error-display>
+    </theoplayer-ui>
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/web/text-tracks/demo.html)
+
+</details>

--- a/docs/examples/default-ui/_category_.json
+++ b/docs/examples/default-ui/_category_.json
@@ -2,5 +2,6 @@
   "label": "Default UI",
   "position": 10,
   "collapsible": true,
-  "collapsed": true
+  "collapsed": true,
+  "description": "Samples demonstrating how to modify the default styling of the player."
 }

--- a/docs/examples/default-ui/_category_.json
+++ b/docs/examples/default-ui/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Default UI",
+  "position": 10,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/examples/default-ui/ads.mdx
+++ b/docs/examples/default-ui/ads.mdx
@@ -1,22 +1,21 @@
 ---
-sidebar_position: 11
+sidebar_position: 2
 sidebar_custom_props: { 'icon': '💰' }
+slug: /web/examples/ads
 ---
 
 # Advertisements
 
-The default UI has full support for advertisements.
-
-During playback, it shows yellow ad markers on the seek bar to indicate the times when the content will be interrupted by an ad.
-
-While playing an ad, the UI shows ad-specific controls such as a skip button and a countdown. These controls are also mobile-aware, for example a
-dedicated clickthrough button replaces the regular clickthrough behavior on desktop.
-
-import Example from '../components/Example';
+import Example from '../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './shared.module.css';
+import styles from '../shared.module.css';
 
 <Example className={styles.player} hideSource src={useBaseUrl('/open-video-ui/v2/examples/web/ads/demo.html')}></Example>
+
+The default UI has full support for advertisements.
+
+During playback, it shows yellow ad markers on the seek bar to indicate the times when the content will be interrupted by an ad. While playing an ad, the UI shows ad-specific controls such as a skip button and a countdown. These controls are also mobile-aware, for example a
+dedicated clickthrough button replaces the regular clickthrough behavior on desktop.
 
 <details>
     <summary>Code</summary>

--- a/docs/examples/default-ui/example.mdx
+++ b/docs/examples/default-ui/example.mdx
@@ -1,15 +1,19 @@
 ---
-sidebar_position: 10
+sidebar_position: 1
 sidebar_custom_props: { 'icon': '▶️' }
+slug: /web/examples/default-ui
+sidebar_label: Default styling
 ---
 
 # Default UI
 
-import Example from '../components/Example';
+import Example from '../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './shared.module.css';
+import styles from '../shared.module.css';
 
 <Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/web/default-ui/demo.html')}></Example>
+
+This sample demonstrates the default UI of the player without any modifications.
 
 <details>
     <summary>Code</summary>

--- a/docs/examples/default-ui/localization.mdx
+++ b/docs/examples/default-ui/localization.mdx
@@ -1,0 +1,60 @@
+---
+sidebar_position: 5
+sidebar_custom_props: { 'icon': '🌍' }
+slug: /web/examples/localization
+---
+
+# Localization
+
+import Example from '../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example
+    className={styles.player}
+    src={useBaseUrl('/open-video-ui/v2/examples/web/localization/demo.html')}
+    hideSource
+    hideDeviceType
+    languages={{ en: 'English', nl: 'Nederlands (Dutch)' }}
+/>
+
+This sample demonstrates localizing the UI and switching language at runtime. A locale is registered with `addLocale`, and the language is selected through the `lang` attribute. Use the dropdown below the player to switch between English and Dutch. See also the [localization guide](../../guides/localization.md).
+
+<details>
+    <summary>Code</summary>
+    ```html showLineNumbers
+    <script type="module">
+        import { addLocale } from '@theoplayer/web-ui';
+
+        addLocale('nl', {
+            playAria: 'afspelen',
+            pauseAria: 'pauzeren',
+            languageMenuHeading: 'Taal',
+            subtitleMenuHeading: 'Ondertitels',
+            subtitleOff: 'Uit',
+            settingsMenuHeading: 'Instellingen'
+        });
+    </script>
+
+    <theoplayer-default-ui
+        id="ui"
+        lang="en"
+        configuration='{"libraryLocation":"/path/to/theoplayer/","license":"your_theoplayer_license"}'
+        source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"}}'
+    ></theoplayer-default-ui>
+
+    <select id="lang-select">
+        <option value="en">English</option>
+        <option value="nl">Nederlands (Dutch)</option>
+    </select>
+
+    <script>
+        document.querySelector('#lang-select').addEventListener('change', (event) => {
+            document.querySelector('#ui').setAttribute('lang', event.target.value);
+        });
+    </script>
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/web/localization/demo.html)
+
+</details>

--- a/docs/examples/default-ui/remove-controls.mdx
+++ b/docs/examples/default-ui/remove-controls.mdx
@@ -1,0 +1,36 @@
+---
+sidebar_position: 4
+sidebar_custom_props: { 'icon': '✂️' }
+slug: /web/examples/remove-controls
+---
+
+# Removing controls
+
+import Example from '../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/web/remove-controls/demo.html')}></Example>
+
+This sample demonstrates how to remove a specific control from the default UI. The default UI exposes its internal controls as [CSS shadow parts](https://developer.mozilla.org/en-US/docs/Web/CSS/::part), so you can hide any of them with `::part()`. Here, we hide the seek bar and keep the rest.
+
+<details>
+    <summary>Code</summary>
+    ```html showLineNumbers
+    <style>
+        /* Hide the seek bar. */
+        theoplayer-default-ui::part(time-range) {
+            display: none;
+        }
+    </style>
+
+    <theoplayer-default-ui
+        configuration='{"libraryLocation":"/path/to/theoplayer/","license":"your_theoplayer_license"}'
+        source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"}}'
+        fluid
+    ></theoplayer-default-ui>
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/web/remove-controls/demo.html)
+
+</details>

--- a/docs/examples/default-ui/styling.mdx
+++ b/docs/examples/default-ui/styling.mdx
@@ -1,13 +1,14 @@
 ---
-sidebar_position: 12
+sidebar_position: 3
 sidebar_custom_props: { 'icon': '🎨' }
+slug: /web/examples/styling
 ---
 
 # Styling the default UI
 
-import StylableExample from '../components/StylableExample';
+import StylableExample from '../../components/StylableExample';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './shared.module.css';
+import styles from '../shared.module.css';
 
 ## Christmas theme
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -84,7 +84,7 @@ sidebar_custom_props: { 'icon': '🚀' }
     ui.player.addEventListener('playing', () => console.log('THEOplayer is now playing'));
     ```
 
-See [this page](examples/default-ui.mdx) for a complete example.
+See [this page](examples/default-ui/example.mdx) for a complete example.
 
 ### Custom UI
 
@@ -107,7 +107,7 @@ If you want to fully customize your video player layout, you can use a `<theopla
 </theoplayer-ui>
 ```
 
-See [this page](examples/custom-ui.mdx) for a complete example.
+See [this page](examples/custom-ui/example.mdx) for a complete example.
 
 ### Legacy browser support
 

--- a/docs/react/examples/custom-ui/_category_.json
+++ b/docs/react/examples/custom-ui/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Custom UI",
+  "position": 2,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/react/examples/custom-ui/_category_.json
+++ b/docs/react/examples/custom-ui/_category_.json
@@ -2,5 +2,6 @@
   "label": "Custom UI",
   "position": 2,
   "collapsible": true,
-  "collapsed": true
+  "collapsed": true,
+  "description": "Samples demonstrating how to implement a custom UI and modify different components."
 }

--- a/docs/react/examples/custom-ui/custom-play-button.mdx
+++ b/docs/react/examples/custom-ui/custom-play-button.mdx
@@ -1,0 +1,70 @@
+---
+sidebar_position: 4
+sidebar_custom_props: { 'icon': '⏯️' }
+slug: /react/examples/custom-play-button
+---
+
+# Custom play button
+
+import Example from '../../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/react/custom-play-button/demo.html')} hideDeviceType />
+
+This sample demonstrates a custom, animated play button. The play/pause icons are overridden through the button's named slots, and the button is styled as a circular badge that gently pulses while the player is paused (the play button reflects its paused state as a `paused` attribute, which we target with CSS).
+
+<details>
+    <summary>Code</summary>
+
+    ```jsx
+    import * as THEOplayerReactUI from '@theoplayer/react-ui';
+
+    // In your stylesheet:
+    //   .big-play { border-radius: 50%; padding: 32px; background: rgba(124, 58, 237, 0.45); backdrop-filter: blur(6px); }
+    //   .big-play svg { width: 64px; height: 64px; }
+    //   .big-play:hover { animation: pulse 3s ease-in-out infinite; }  /* only pulse on hover */
+    //   @keyframes pulse { 0%, 100% { transform: scale(1); } 50% { transform: scale(1.06); } }
+
+    const configuration = {
+        libraryLocation: '/path/to/theoplayer/',
+        license: 'your_theoplayer_license'
+    };
+
+    const source = {
+        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+        metadata: { title: 'Big Buck Bunny' }
+    };
+
+    const App = () => {
+        return (
+            <THEOplayerReactUI.UIContainer
+                configuration={configuration}
+                source={source}
+                centeredChrome={
+                    <THEOplayerReactUI.PlayButton className="big-play">
+                        <svg slot="play-icon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor">
+                            <path d="M8 5v14l11-7z" />
+                        </svg>
+                        <svg slot="pause-icon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor">
+                            <path d="M6 5h4v14H6zM14 5h4v14h-4z" />
+                        </svg>
+                    </THEOplayerReactUI.PlayButton>
+                }
+                bottomChrome={
+                    <THEOplayerReactUI.ControlBar>
+                        <THEOplayerReactUI.PlayButton />
+                        <THEOplayerReactUI.MuteButton />
+                        <THEOplayerReactUI.TimeDisplay showDuration />
+                        <THEOplayerReactUI.FullscreenButton />
+                    </THEOplayerReactUI.ControlBar>
+                }
+                error={<THEOplayerReactUI.ErrorDisplay />}
+            />
+        );
+    };
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/react/custom-play-button/demo.html)
+
+</details>

--- a/docs/react/examples/custom-ui/example.mdx
+++ b/docs/react/examples/custom-ui/example.mdx
@@ -1,16 +1,19 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 sidebar_custom_props: { 'icon': '▶️' }
 slug: /react/examples/custom-ui
+sidebar_label: Custom styling
 ---
 
 # Custom UI
 
-import Example from '../../components/Example';
+import Example from '../../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './shared.module.css';
+import styles from '../shared.module.css';
 
 <Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/react/custom-ui/demo.html')} hideDeviceType />
+
+This sample demonstrates a basic custom UI.
 
 <details>
     <summary>Code</summary>

--- a/docs/react/examples/custom-ui/modern.mdx
+++ b/docs/react/examples/custom-ui/modern.mdx
@@ -1,0 +1,79 @@
+---
+sidebar_position: 3
+sidebar_custom_props: { 'icon': '✨' }
+slug: /react/examples/modern
+---
+
+# Modern UI
+
+import Example from '../../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/react/modern/demo.html')} hideDeviceType />
+
+This sample demonstrates a modern, streaming-service style custom UI: a centered playback pill with rewind, play/pause and forward, a full-width seek bar, and rounded translucent control clusters.
+
+<details>
+    <summary>Code</summary>
+
+    ```jsx
+    import * as THEOplayerReactUI from '@theoplayer/react-ui';
+
+    const configuration = {
+        libraryLocation: '/path/to/theoplayer/',
+        license: 'your_theoplayer_license'
+    };
+
+    const source = {
+        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+        metadata: { title: 'Big Buck Bunny' }
+    };
+
+    const Spacer = () => <span className="spacer" />;
+
+    const App = () => {
+        return (
+            <THEOplayerReactUI.UIContainer
+                configuration={configuration}
+                source={source}
+                centeredChrome={
+                    <div className="pill center-pill">
+                        <THEOplayerReactUI.SeekButton seekOffset={-10} />
+                        <THEOplayerReactUI.PlayButton />
+                        <THEOplayerReactUI.SeekButton seekOffset={10} />
+                    </div>
+                }
+                centeredLoading={<THEOplayerReactUI.LoadingIndicator />}
+                bottomChrome={
+                    <div className="bottom-chrome">
+                        <THEOplayerReactUI.ControlBar>
+                            <THEOplayerReactUI.TimeRange />
+                        </THEOplayerReactUI.ControlBar>
+                        <div className="bottom-row">
+                            <span className="pill">
+                                <THEOplayerReactUI.PlayButton />
+                                <span className="volume">
+                                    <THEOplayerReactUI.MuteButton />
+                                    <THEOplayerReactUI.VolumeRange />
+                                </span>
+                                <THEOplayerReactUI.TimeDisplay showDuration />
+                            </span>
+                            <Spacer />
+                            <span className="pill">
+                                <THEOplayerReactUI.LanguageMenuButton menu="language-menu" />
+                                <THEOplayerReactUI.FullscreenButton />
+                            </span>
+                        </div>
+                    </div>
+                }
+                menu={<THEOplayerReactUI.LanguageMenu id="language-menu" />}
+                error={<THEOplayerReactUI.ErrorDisplay />}
+            />
+        );
+    };
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/react/modern/demo.html)
+
+</details>

--- a/docs/react/examples/custom-ui/text-tracks.mdx
+++ b/docs/react/examples/custom-ui/text-tracks.mdx
@@ -1,0 +1,153 @@
+---
+sidebar_position: 2
+sidebar_custom_props: { 'icon': '💬' }
+slug: /react/examples/text-tracks
+---
+
+# Text tracks and subtitles
+
+import Example from '../../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/react/text-tracks/demo.html')} hideSource hideDeviceType />
+
+This example demonstrates the text track components for subtitle selection and styling.
+
+The settings menu contains four submenus:
+
+- **Subtitles**: the idiomatic `TrackRadioGroup` with `trackType="subtitles"` and `show-off`, which composes `TextTrackOffRadioButton` and `TextTrackRadioButton` for you.
+- **Subtitles (custom)**: the same picker built manually from `TextTrackOffRadioButton` and `TextTrackRadioButton`.
+- **Subtitle appearance**: the pre-built `TextTrackStyleMenu`, which composes `TextTrackStyleDisplay`, `TextTrackStyleRadioGroup` and `TextTrackStyleResetButton`.
+- **Font color (custom)**: a single style option built manually from `TextTrackStyleRadioGroup` and `TextTrackStyleResetButton`.
+
+<details>
+    <summary>Code</summary>
+
+    ```jsx
+    import * as THEOplayerReactUI from '@theoplayer/react-ui';
+    import { useContext, useEffect, useState } from 'react';
+
+    const configuration = {
+        libraryLocation: '/path/to/theoplayer/',
+        license: 'your_theoplayer_license'
+    };
+
+    const source = {
+        sources: { src: 'https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8' },
+        metadata: { title: "Elephant's Dream" }
+    };
+
+    // A hook returning the player's subtitle text tracks.
+    const useSubtitleTracks = () => {
+        const player = useContext(THEOplayerReactUI.PlayerContext);
+        const [tracks, setTracks] = useState([]);
+        useEffect(() => {
+            if (!player) return;
+            const textTracks = player.textTracks;
+            const update = () => {
+                setTracks(textTracks.filter((t) => t.kind === 'subtitles' || t.kind === 'captions'));
+            };
+            update();
+            textTracks.addEventListener(['addtrack', 'removetrack'], update);
+            return () => textTracks.removeEventListener(['addtrack', 'removetrack'], update);
+        }, [player]);
+        return { player, tracks };
+    };
+
+    // A subtitle picker built from the low-level TextTrackOffRadioButton and TextTrackRadioButton.
+    // In practice, prefer <TrackRadioGroup trackType="subtitles" show-off />, which composes these for you.
+    const CustomSubtitlePicker = () => {
+        const { player, tracks } = useSubtitleTracks();
+        return (
+            <THEOplayerReactUI.RadioGroup>
+                <THEOplayerReactUI.TextTrackOffRadioButton trackList={player?.textTracks} />
+                {tracks.map((track) => (
+                    <THEOplayerReactUI.TextTrackRadioButton key={track.uid} track={track} />
+                ))}
+            </THEOplayerReactUI.RadioGroup>
+        );
+    };
+
+    const FONT_COLORS = [
+        { label: 'Default', value: '' },
+        { label: 'White', value: 'rgb(255,255,255)' },
+        { label: 'Yellow', value: 'rgb(255,255,0)' },
+        { label: 'Green', value: 'rgb(0,255,0)' },
+        { label: 'Cyan', value: 'rgb(0,255,255)' },
+        { label: 'Blue', value: 'rgb(0,0,255)' },
+        { label: 'Magenta', value: 'rgb(255,0,255)' },
+        { label: 'Red', value: 'rgb(255,0,0)' },
+        { label: 'Black', value: 'rgb(0,0,0)' }
+    ];
+
+    const App = () => {
+        return (
+            <THEOplayerReactUI.UIContainer
+                configuration={configuration}
+                source={source}
+                bottomChrome={
+                    <THEOplayerReactUI.ControlBar>
+                        <THEOplayerReactUI.PlayButton />
+                        <THEOplayerReactUI.MuteButton />
+                        <THEOplayerReactUI.VolumeRange />
+                        <THEOplayerReactUI.TimeDisplay />
+                        <THEOplayerReactUI.LanguageMenuButton menu="language-menu" />
+                        <THEOplayerReactUI.MenuButton menu="settings-menu">CC</THEOplayerReactUI.MenuButton>
+                        <THEOplayerReactUI.FullscreenButton />
+                    </THEOplayerReactUI.ControlBar>
+                }
+                menu={
+                    <>
+                        <THEOplayerReactUI.LanguageMenu id="language-menu" />
+                        <THEOplayerReactUI.MenuGroup id="settings-menu">
+                            <THEOplayerReactUI.Menu heading="Subtitles & captions">
+                                <THEOplayerReactUI.MenuButton menu="subtitle-menu">
+                                    <span>Select</span>
+                                </THEOplayerReactUI.MenuButton>
+                                <THEOplayerReactUI.MenuButton menu="subtitle-style-menu">
+                                    <THEOplayerReactUI.TextTrackStyleDisplay property="fontColor" />
+                                </THEOplayerReactUI.MenuButton>
+                            </THEOplayerReactUI.Menu>
+
+                            {/* Idiomatic subtitle picker using TrackRadioGroup. */}
+                            <THEOplayerReactUI.Menu id="subtitle-menu" closeOnInput hidden heading="Subtitles">
+                                <THEOplayerReactUI.TrackRadioGroup trackType="subtitles" show-off />
+                            </THEOplayerReactUI.Menu>
+
+                            {/* Manual subtitle picker using TextTrackOffRadioButton and TextTrackRadioButton. */}
+                            <THEOplayerReactUI.Menu id="subtitle-custom-menu" closeOnInput hidden heading="Subtitles (custom)">
+                                <CustomSubtitlePicker />
+                            </THEOplayerReactUI.Menu>
+
+                            {/* Pre-built subtitle style menu. */}
+                            <THEOplayerReactUI.TextTrackStyleMenu
+                                id="subtitle-style-menu"
+                                closeOnInput
+                                hidden
+                                heading="Subtitle appearance"
+                            />
+
+                            {/* Manual font color submenu using TextTrackStyleRadioGroup and TextTrackStyleResetButton. */}
+                            <THEOplayerReactUI.Menu id="font-color-menu" closeOnInput hidden heading="Font color (custom)">
+                                <THEOplayerReactUI.TextTrackStyleResetButton slot="heading" />
+                                <THEOplayerReactUI.TextTrackStyleRadioGroup property="fontColor">
+                                    {FONT_COLORS.map(({ label, value }) => (
+                                        <THEOplayerReactUI.RadioButton key={value} value={value}>
+                                            {label}
+                                        </THEOplayerReactUI.RadioButton>
+                                    ))}
+                                </THEOplayerReactUI.TextTrackStyleRadioGroup>
+                            </THEOplayerReactUI.Menu>
+                        </THEOplayerReactUI.MenuGroup>
+                    </>
+                }
+                error={<THEOplayerReactUI.ErrorDisplay />}
+            />
+        );
+    };
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/react/text-tracks/demo.html)
+
+</details>

--- a/docs/react/examples/default-ui/_category_.json
+++ b/docs/react/examples/default-ui/_category_.json
@@ -2,5 +2,6 @@
   "label": "Default UI",
   "position": 1,
   "collapsible": true,
-  "collapsed": true
+  "collapsed": true,
+  "description": "Samples demonstrating how to modify the default styling of the player."
 }

--- a/docs/react/examples/default-ui/_category_.json
+++ b/docs/react/examples/default-ui/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Default UI",
+  "position": 1,
+  "collapsible": true,
+  "collapsed": true
+}

--- a/docs/react/examples/default-ui/example.mdx
+++ b/docs/react/examples/default-ui/example.mdx
@@ -2,15 +2,18 @@
 sidebar_position: 1
 sidebar_custom_props: { 'icon': '▶️' }
 slug: /react/examples/default-ui
+sidebar_label: Default styling
 ---
 
 # Default UI
 
-import Example from '../../components/Example';
+import Example from '../../../components/Example';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import styles from './shared.module.css';
+import styles from '../shared.module.css';
 
 <Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/react/default-ui/demo.html')} />
+
+This sample demonstrates the default UI of the player without any modifications.
 
 <details>
     <summary>Code</summary>

--- a/docs/react/examples/default-ui/localization.mdx
+++ b/docs/react/examples/default-ui/localization.mdx
@@ -1,0 +1,67 @@
+---
+sidebar_position: 3
+sidebar_custom_props: { 'icon': '🌍' }
+slug: /react/examples/localization
+---
+
+# Localization
+
+import Example from '../../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example
+    className={styles.player}
+    src={useBaseUrl('/open-video-ui/v2/examples/react/localization/demo.html')}
+    hideSource
+    hideDeviceType
+    languages={{ en: 'English', nl: 'Nederlands (Dutch)' }}
+/>
+
+This sample demonstrates localizing the UI and switching language at runtime. A locale is registered with `addLocale`, and the language is selected through the `lang` prop. Use the dropdown below the player to switch between English and Dutch. See also the [localization guide](../../guides/localization.md).
+
+<details>
+    <summary>Code</summary>
+
+    ```jsx
+    import { useState } from 'react';
+    import { DefaultUI, addLocale } from '@theoplayer/react-ui';
+
+    const configuration = {
+        libraryLocation: '/path/to/theoplayer/',
+        license: 'your_theoplayer_license'
+    };
+
+    const source = {
+        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+        metadata: { title: 'Big Buck Bunny' }
+    };
+
+    // Register the Dutch locale. Untranslated messages fall back to the built-in English defaults.
+    addLocale('nl', {
+        playAria: 'afspelen',
+        pauseAria: 'pauzeren',
+        languageMenuHeading: 'Taal',
+        subtitleMenuHeading: 'Ondertitels',
+        subtitleOff: 'Uit',
+        settingsMenuHeading: 'Instellingen'
+        // ...
+    });
+
+    const App = () => {
+        const [lang, setLang] = useState('en');
+        return (
+            <>
+                <DefaultUI configuration={configuration} source={source} lang={lang} />
+                <select value={lang} onChange={(event) => setLang(event.target.value)}>
+                    <option value="en">English</option>
+                    <option value="nl">Nederlands (Dutch)</option>
+                </select>
+            </>
+        );
+    };
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/react/localization/demo.html)
+
+</details>

--- a/docs/react/examples/default-ui/remove-controls.mdx
+++ b/docs/react/examples/default-ui/remove-controls.mdx
@@ -1,0 +1,46 @@
+---
+sidebar_position: 2
+sidebar_custom_props: { 'icon': '✂️' }
+slug: /react/examples/remove-controls
+---
+
+# Removing controls
+
+import Example from '../../../components/Example';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import styles from '../shared.module.css';
+
+<Example className={styles.player} src={useBaseUrl('/open-video-ui/v2/examples/react/remove-controls/demo.html')} />
+
+This sample demonstrates how to remove a specific control from the default UI. The default UI exposes its internal controls as [CSS shadow parts](https://developer.mozilla.org/en-US/docs/Web/CSS/::part), so you can hide any of them with `::part()` — here we hide the seek bar and keep the rest.
+
+<details>
+    <summary>Code</summary>
+
+    ```jsx
+    import { DefaultUI } from '@theoplayer/react-ui';
+
+    // In your stylesheet, hide the seek bar by targeting its shadow part:
+    //
+    //   theoplayer-default-ui::part(time-range) {
+    //       display: none;
+    //   }
+
+    const configuration = {
+        libraryLocation: '/path/to/theoplayer/',
+        license: 'your_theoplayer_license'
+    };
+
+    const source = {
+        sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+        metadata: { title: 'Big Buck Bunny' }
+    };
+
+    const App = () => {
+        return <DefaultUI configuration={configuration} source={source} />;
+    };
+    ```
+
+    [📜 View full source on GitHub](https://github.com/THEOplayer/web-ui/blob/main/docs/static/open-video-ui/v2/examples/react/remove-controls/demo.html)
+
+</details>

--- a/docs/react/getting-started.mdx
+++ b/docs/react/getting-started.mdx
@@ -59,7 +59,7 @@ const App = () => {
 };
 ```
 
-See [this page](examples/default-ui.mdx) for a complete example.
+See [this page](examples/default-ui/example.mdx) for a complete example.
 
 ### Custom UI
 
@@ -101,7 +101,7 @@ const App = () => {
 };
 ```
 
-See [this page](examples/custom-ui.mdx) for a complete example.
+See [this page](examples/custom-ui/example.mdx) for a complete example.
 
 ### Legacy browser support
 

--- a/docs/static/open-video-ui/v2/examples/react/custom-play-button/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/custom-play-button/demo.html
@@ -77,8 +77,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
-                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.3.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/dist/THEOplayerUI.mjs",
                     "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
                     "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
                     "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
@@ -105,7 +105,7 @@
         <!-- Use Babel for JSX in <script> tags -->
         <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
         <!-- Polyfills for older browsers -->
-        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/polyfills"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/docs/static/open-video-ui/v2/examples/react/custom-play-button/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/custom-play-button/demo.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Custom play button with React</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                background: #000;
+            }
+
+            theoplayer-ui {
+                width: 100%;
+                font-family: 'Noto Sans', sans-serif;
+            }
+
+            .spacer {
+                flex-grow: 1;
+            }
+
+            .bottom-chrome {
+                position: relative;
+                display: flex;
+                flex-flow: column nowrap;
+                align-items: stretch;
+            }
+
+            .big-play {
+                color: #fff;
+                background: rgba(124, 58, 237, 0.45);
+                backdrop-filter: blur(6px);
+                border-radius: 50%;
+                padding: 32px;
+                box-shadow: 0 4px 20px rgba(124, 58, 237, 0.4);
+                transition:
+                    transform 0.4s ease,
+                    box-shadow 0.4s ease,
+                    background 0.4s ease;
+            }
+
+            .big-play svg {
+                width: 64px;
+                height: 64px;
+            }
+
+            /* Only animate while hovered; the transition smoothly returns it when the pointer leaves. */
+            .big-play:hover {
+                background: rgba(139, 92, 246, 0.55);
+                animation: pulse 3s ease-in-out infinite;
+            }
+
+            @keyframes pulse {
+                0%,
+                100% {
+                    transform: scale(1);
+                    box-shadow: 0 4px 20px rgba(124, 58, 237, 0.35);
+                }
+                50% {
+                    transform: scale(1.06);
+                    box-shadow: 0 6px 26px rgba(124, 58, 237, 0.6);
+                }
+            }
+        </style>
+        <script type="importmap">
+            {
+                "imports": {
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
+                    "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
+                    "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
+                    "@lit/react": "https://ga.jspm.io/npm:@lit/react@1.0.4/index.js",
+                    "react": "https://ga.jspm.io/npm:react@18.2.0/index.js",
+                    "react-dom/client": "https://ga.jspm.io/npm:react-dom@18.2.0/client.js",
+                    "theoplayer/chromeless": "https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.esm.js"
+                },
+                "scopes": {
+                    "https://ga.jspm.io/": {
+                        "@lit/reactive-element": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/reactive-element.js",
+                        "@lit/reactive-element/decorators/": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/decorators/",
+                        "lit-element/lit-element.js": "https://ga.jspm.io/npm:lit-element@4.2.1/lit-element.js",
+                        "lit-html": "https://ga.jspm.io/npm:lit-html@3.3.1/lit-html.js",
+                        "lit-html/": "https://ga.jspm.io/npm:lit-html@3.3.1/",
+                        "react-dom": "https://ga.jspm.io/npm:react-dom@18.2.0/index.js",
+                        "scheduler": "https://ga.jspm.io/npm:scheduler@0.23.0/index.js"
+                    }
+                }
+            }
+        </script>
+        <!-- Import maps polyfill for browsers without import maps support (e.g. Safari 16.3) -->
+        <script async src="https://ga.jspm.io/npm:es-module-shims@2.6.2/dist/es-module-shims.js" crossorigin="anonymous"></script>
+        <!-- Use Babel for JSX in <script> tags -->
+        <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+        <!-- Polyfills for older browsers -->
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <script type="text/babel" data-type="module">
+            import * as React from 'react';
+            import { createRoot } from 'react-dom/client';
+            import * as THEOplayerReactUI from '@theoplayer/react-ui';
+            import { useDeviceTypeFromParent, useSourceFromParent } from '../utils.js';
+
+            const configuration = {
+                /**
+                 * libraryLocation: For demonstration purposes, we use the free unpkg.com CDN.
+                 * For production use, we recommend hosting THEOplayer yourself
+                 * and changing this (as well as the <script> and <link> tags above)
+                 * to point to THEOplayer's location on your own website.
+                 */
+                libraryLocation: 'https://cdn.theoplayer.com/dash/theoplayer/',
+                /**
+                 * licenseUrl: Change this to point to your THEOplayer license file.
+                 * Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+                 */
+                licenseUrl: '../../../../../theoplayer-license.txt'
+            };
+
+            const defaultSource = {
+                sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+                metadata: {
+                    title: 'Big Buck Bunny'
+                }
+            };
+
+            const Spacer = () => <span className="spacer" />;
+
+            const App = () => {
+                const source = useSourceFromParent() || defaultSource;
+                const deviceType = useDeviceTypeFromParent() || null;
+                return (
+                    <THEOplayerReactUI.UIContainer
+                        configuration={configuration}
+                        source={source}
+                        device-type={deviceType}
+                        centeredLoading={<THEOplayerReactUI.LoadingIndicator />}
+                        centeredChrome={
+                            <THEOplayerReactUI.PlayButton className="big-play">
+                                <svg slot="play-icon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor">
+                                    <path d="M8 5v14l11-7z" />
+                                </svg>
+                                <svg slot="pause-icon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor">
+                                    <path d="M6 5h4v14H6zM14 5h4v14h-4z" />
+                                </svg>
+                            </THEOplayerReactUI.PlayButton>
+                        }
+                        bottomChrome={
+                            <div className="bottom-chrome">
+                                <THEOplayerReactUI.ControlBar>
+                                    <THEOplayerReactUI.TimeRange />
+                                </THEOplayerReactUI.ControlBar>
+                                <THEOplayerReactUI.ControlBar>
+                                    <THEOplayerReactUI.PlayButton />
+                                    <THEOplayerReactUI.MuteButton />
+                                    <THEOplayerReactUI.VolumeRange />
+                                    <THEOplayerReactUI.TimeDisplay showDuration />
+                                    <Spacer />
+                                    <THEOplayerReactUI.FullscreenButton />
+                                </THEOplayerReactUI.ControlBar>
+                            </div>
+                        }
+                        error={<THEOplayerReactUI.ErrorDisplay />}
+                    />
+                );
+            };
+
+            const root = createRoot(document.getElementById('app'));
+            root.render(<App />);
+        </script>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/react/custom-ui/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/custom-ui/demo.html
@@ -59,8 +59,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
-                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.3.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/dist/THEOplayerUI.mjs",
                     "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
                     "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
                     "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
@@ -87,7 +87,7 @@
         <!-- Use Babel for JSX in <script> tags -->
         <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
         <!-- Polyfills for older browsers -->
-        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/polyfills"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/docs/static/open-video-ui/v2/examples/react/default-ui/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/default-ui/demo.html
@@ -34,8 +34,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
-                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.3.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/dist/THEOplayerUI.mjs",
                     "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
                     "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
                     "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
@@ -62,7 +62,7 @@
         <!-- Use Babel for JSX in <script> tags -->
         <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
         <!-- Polyfills for older browsers -->
-        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/polyfills"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/docs/static/open-video-ui/v2/examples/react/localization/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/localization/demo.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Localization with React</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-default-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                background: #000;
+            }
+
+            theoplayer-default-ui {
+                font-family: 'Noto Sans', sans-serif;
+                width: 100%;
+            }
+        </style>
+        <script type="importmap">
+            {
+                "imports": {
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
+                    "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
+                    "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
+                    "@lit/react": "https://ga.jspm.io/npm:@lit/react@1.0.4/index.js",
+                    "react": "https://ga.jspm.io/npm:react@18.2.0/index.js",
+                    "react-dom/client": "https://ga.jspm.io/npm:react-dom@18.2.0/client.js",
+                    "theoplayer/chromeless": "https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.esm.js"
+                },
+                "scopes": {
+                    "https://ga.jspm.io/": {
+                        "@lit/reactive-element": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/reactive-element.js",
+                        "@lit/reactive-element/decorators/": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/decorators/",
+                        "lit-element/lit-element.js": "https://ga.jspm.io/npm:lit-element@4.2.1/lit-element.js",
+                        "lit-html": "https://ga.jspm.io/npm:lit-html@3.3.1/lit-html.js",
+                        "lit-html/": "https://ga.jspm.io/npm:lit-html@3.3.1/",
+                        "react-dom": "https://ga.jspm.io/npm:react-dom@18.2.0/index.js",
+                        "scheduler": "https://ga.jspm.io/npm:scheduler@0.23.0/index.js"
+                    }
+                }
+            }
+        </script>
+        <!-- Import maps polyfill for browsers without import maps support (e.g. Safari 16.3) -->
+        <script async src="https://ga.jspm.io/npm:es-module-shims@2.6.2/dist/es-module-shims.js" crossorigin="anonymous"></script>
+        <!-- Use Babel for JSX in <script> tags -->
+        <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+        <!-- Polyfills for older browsers -->
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <script type="text/babel" data-type="module">
+            import * as React from 'react';
+            import { createRoot } from 'react-dom/client';
+            import * as THEOplayerReactUI from '@theoplayer/react-ui';
+            import { useDeviceTypeFromParent, useLanguageFromParent, useSourceFromParent } from '../utils.js';
+
+            const configuration = {
+                /**
+                 * libraryLocation: For demonstration purposes, we use the free unpkg.com CDN.
+                 * For production use, we recommend hosting THEOplayer yourself
+                 * and changing this (as well as the <script> and <link> tags above)
+                 * to point to THEOplayer's location on your own website.
+                 */
+                libraryLocation: 'https://cdn.theoplayer.com/dash/theoplayer/',
+                /**
+                 * licenseUrl: Change this to point to your THEOplayer license file.
+                 * Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+                 */
+                licenseUrl: '../../../../../theoplayer-license.txt'
+            };
+
+            const defaultSource = {
+                sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+                metadata: {
+                    title: 'Big Buck Bunny'
+                }
+            };
+
+            // Register the Dutch locale. Untranslated messages fall back to the built-in English defaults.
+            THEOplayerReactUI.addLocale('nl', {
+                playAria: 'afspelen',
+                pauseAria: 'pauzeren',
+                replayAria: 'opnieuw afspelen',
+                muteAria: 'dempen',
+                unmuteAria: 'dempen opheffen',
+                volumeAria: 'volume',
+                seekAria: 'zoeken',
+                seekForwardAria: (offset) => `spring voorwaarts met ${offset}`,
+                seekBackwardAria: (offset) => `spring achterwaarts met ${offset}`,
+                live: 'LIVE',
+                seekToLiveAria: 'spring naar live',
+                fullscreenAria: 'volledig scherm',
+                fullscreenExitAria: 'volledig scherm sluiten',
+                closeMenuAria: 'menu sluiten',
+                openLanguageMenuAria: 'taalmenu openen',
+                languageMenuHeading: 'Taal',
+                audioMenuHeading: 'Audio',
+                subtitleMenuHeading: 'Ondertitels',
+                subtitleOff: 'Uit',
+                openSettingsMenuAria: 'instellingenmenu openen',
+                settingsMenuHeading: 'Instellingen',
+                qualityMenuHeading: 'Kwaliteit',
+                playbackRateMenuHeading: 'Afspeelsnelheid',
+                formatPlaybackRate: (rate) => (rate === 1 ? 'Normaal' : `${rate}x`),
+                automaticQualityLabel: 'Automatisch',
+                errorHeading: 'Er is een fout opgetreden'
+            });
+
+            const App = () => {
+                const source = useSourceFromParent() || defaultSource;
+                const deviceType = useDeviceTypeFromParent() || null;
+                // The language is selected through the dropdown rendered below the player.
+                const lang = useLanguageFromParent() || 'en';
+                return (
+                    <THEOplayerReactUI.DefaultUI
+                        configuration={configuration}
+                        source={source}
+                        device-type={deviceType}
+                        lang={lang}
+                        title={<span>{source.metadata.title}</span>}
+                    />
+                );
+            };
+
+            const root = createRoot(document.getElementById('app'));
+            root.render(<App />);
+        </script>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/react/localization/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/localization/demo.html
@@ -30,8 +30,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
-                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.3.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/dist/THEOplayerUI.mjs",
                     "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
                     "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
                     "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
@@ -58,7 +58,7 @@
         <!-- Use Babel for JSX in <script> tags -->
         <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
         <!-- Polyfills for older browsers -->
-        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/polyfills"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/docs/static/open-video-ui/v2/examples/react/modern/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/modern/demo.html
@@ -101,8 +101,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
-                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.3.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/dist/THEOplayerUI.mjs",
                     "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
                     "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
                     "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
@@ -129,7 +129,7 @@
         <!-- Use Babel for JSX in <script> tags -->
         <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
         <!-- Polyfills for older browsers -->
-        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/polyfills"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/docs/static/open-video-ui/v2/examples/react/modern/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/modern/demo.html
@@ -1,0 +1,224 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Modern UI with React</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                background: #000;
+            }
+
+            theoplayer-ui {
+                width: 100%;
+                font-family: 'Noto Sans', sans-serif;
+
+                /* Dolby OptiView purple accent. */
+                --theoplayer-range-bar-color: #a855f7;
+                --theoplayer-range-thumb-background: radial-gradient(circle, #c084fc, #7c3aed);
+                --theoplayer-control-background-gradient-stops: transparent 0%, rgba(46, 16, 101, 0.85) 100%;
+            }
+
+            .title {
+                user-select: none;
+                color: #fff;
+                text-shadow: 0 0 4px rgba(0, 0, 0, 0.75);
+                font-size: 14px;
+                line-height: 24px;
+                padding: 10px;
+            }
+
+            .spacer {
+                flex-grow: 1;
+            }
+
+            .bottom-row {
+                display: flex;
+                flex-flow: row nowrap;
+                align-items: center;
+                gap: 8px;
+                padding: 0 8px 8px;
+            }
+
+            .bottom-chrome {
+                position: relative;
+                display: flex;
+                flex-flow: column nowrap;
+                align-items: stretch;
+            }
+
+            .pill {
+                display: inline-flex;
+                align-items: center;
+                border-radius: 999px;
+                background: linear-gradient(135deg, rgba(109, 40, 217, 0.55), rgba(168, 85, 247, 0.45));
+                backdrop-filter: blur(3px);
+            }
+
+            .bottom-row .pill {
+                height: 44px;
+            }
+
+            .volume {
+                display: inline-flex;
+                align-items: center;
+            }
+
+            .volume-slider {
+                display: inline-flex;
+                align-items: center;
+                width: 0;
+                overflow: hidden;
+                transition: width 0.2s ease;
+            }
+
+            .volume:hover .volume-slider {
+                width: 100px;
+            }
+
+            .center-pill {
+                padding: 4px 10px;
+                gap: 8px;
+            }
+
+            .center-pill * {
+                --theoplayer-control-height: 48px;
+            }
+        </style>
+        <script type="importmap">
+            {
+                "imports": {
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
+                    "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
+                    "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
+                    "@lit/react": "https://ga.jspm.io/npm:@lit/react@1.0.4/index.js",
+                    "react": "https://ga.jspm.io/npm:react@18.2.0/index.js",
+                    "react-dom/client": "https://ga.jspm.io/npm:react-dom@18.2.0/client.js",
+                    "theoplayer/chromeless": "https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.esm.js"
+                },
+                "scopes": {
+                    "https://ga.jspm.io/": {
+                        "@lit/reactive-element": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/reactive-element.js",
+                        "@lit/reactive-element/decorators/": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/decorators/",
+                        "lit-element/lit-element.js": "https://ga.jspm.io/npm:lit-element@4.2.1/lit-element.js",
+                        "lit-html": "https://ga.jspm.io/npm:lit-html@3.3.1/lit-html.js",
+                        "lit-html/": "https://ga.jspm.io/npm:lit-html@3.3.1/",
+                        "react-dom": "https://ga.jspm.io/npm:react-dom@18.2.0/index.js",
+                        "scheduler": "https://ga.jspm.io/npm:scheduler@0.23.0/index.js"
+                    }
+                }
+            }
+        </script>
+        <!-- Import maps polyfill for browsers without import maps support (e.g. Safari 16.3) -->
+        <script async src="https://ga.jspm.io/npm:es-module-shims@2.6.2/dist/es-module-shims.js" crossorigin="anonymous"></script>
+        <!-- Use Babel for JSX in <script> tags -->
+        <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+        <!-- Polyfills for older browsers -->
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <script type="text/babel" data-type="module">
+            import * as React from 'react';
+            import { createRoot } from 'react-dom/client';
+            import * as THEOplayerReactUI from '@theoplayer/react-ui';
+            import { useDeviceTypeFromParent, useSourceFromParent } from '../utils.js';
+
+            const configuration = {
+                /**
+                 * libraryLocation: For demonstration purposes, we use the free unpkg.com CDN.
+                 * For production use, we recommend hosting THEOplayer yourself
+                 * and changing this (as well as the <script> and <link> tags above)
+                 * to point to THEOplayer's location on your own website.
+                 */
+                libraryLocation: 'https://cdn.theoplayer.com/dash/theoplayer/',
+                /**
+                 * licenseUrl: Change this to point to your THEOplayer license file.
+                 * Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+                 */
+                licenseUrl: '../../../../../theoplayer-license.txt'
+            };
+
+            const defaultSource = {
+                sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+                metadata: {
+                    title: 'Big Buck Bunny'
+                }
+            };
+
+            const Spacer = () => <span className="spacer" />;
+
+            const App = () => {
+                const source = useSourceFromParent() || defaultSource;
+                const deviceType = useDeviceTypeFromParent() || null;
+                const title = source.metadata.title;
+                return (
+                    <THEOplayerReactUI.UIContainer
+                        configuration={configuration}
+                        source={source}
+                        device-type={deviceType}
+                        topChrome={
+                            <THEOplayerReactUI.ControlBar>
+                                <span className="title">{title}</span>
+                                <Spacer />
+                            </THEOplayerReactUI.ControlBar>
+                        }
+                        centeredChrome={
+                            <div className="pill center-pill">
+                                <THEOplayerReactUI.SeekButton seekOffset={-10} />
+                                <THEOplayerReactUI.PlayButton />
+                                <THEOplayerReactUI.SeekButton seekOffset={10} />
+                            </div>
+                        }
+                        centeredLoading={<THEOplayerReactUI.LoadingIndicator />}
+                        bottomChrome={
+                            <div className="bottom-chrome">
+                                <THEOplayerReactUI.ControlBar>
+                                    <THEOplayerReactUI.TimeRange />
+                                </THEOplayerReactUI.ControlBar>
+                                <div className="bottom-row">
+                                    <span className="pill">
+                                        <THEOplayerReactUI.PlayButton />
+                                        <span className="volume">
+                                            <THEOplayerReactUI.MuteButton />
+                                            <span className="volume-slider">
+                                                <THEOplayerReactUI.VolumeRange />
+                                            </span>
+                                        </span>
+                                        <THEOplayerReactUI.TimeDisplay showDuration />
+                                    </span>
+                                    <Spacer />
+                                    <span className="pill">
+                                        <THEOplayerReactUI.LanguageMenuButton menu="language-menu" />
+                                        <THEOplayerReactUI.FullscreenButton />
+                                    </span>
+                                </div>
+                            </div>
+                        }
+                        menu={<THEOplayerReactUI.LanguageMenu id="language-menu" />}
+                        error={<THEOplayerReactUI.ErrorDisplay />}
+                    />
+                );
+            };
+
+            const root = createRoot(document.getElementById('app'));
+            root.render(<App />);
+        </script>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/react/remove-controls/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/remove-controls/demo.html
@@ -35,8 +35,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
-                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.3.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/dist/THEOplayerUI.mjs",
                     "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
                     "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
                     "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
@@ -63,7 +63,7 @@
         <!-- Use Babel for JSX in <script> tags -->
         <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
         <!-- Polyfills for older browsers -->
-        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/polyfills"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/docs/static/open-video-ui/v2/examples/react/remove-controls/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/remove-controls/demo.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Removing controls with React</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-default-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                background: #000;
+            }
+
+            theoplayer-default-ui {
+                font-family: 'Noto Sans', sans-serif;
+                width: 100%;
+            }
+
+            /* Hide the seek bar by targeting its shadow part, keeping all other controls. */
+            theoplayer-default-ui::part(time-range) {
+                display: none;
+            }
+        </style>
+        <script type="importmap">
+            {
+                "imports": {
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
+                    "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
+                    "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
+                    "@lit/react": "https://ga.jspm.io/npm:@lit/react@1.0.4/index.js",
+                    "react": "https://ga.jspm.io/npm:react@18.2.0/index.js",
+                    "react-dom/client": "https://ga.jspm.io/npm:react-dom@18.2.0/client.js",
+                    "theoplayer/chromeless": "https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.esm.js"
+                },
+                "scopes": {
+                    "https://ga.jspm.io/": {
+                        "@lit/reactive-element": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/reactive-element.js",
+                        "@lit/reactive-element/decorators/": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/decorators/",
+                        "lit-element/lit-element.js": "https://ga.jspm.io/npm:lit-element@4.2.1/lit-element.js",
+                        "lit-html": "https://ga.jspm.io/npm:lit-html@3.3.1/lit-html.js",
+                        "lit-html/": "https://ga.jspm.io/npm:lit-html@3.3.1/",
+                        "react-dom": "https://ga.jspm.io/npm:react-dom@18.2.0/index.js",
+                        "scheduler": "https://ga.jspm.io/npm:scheduler@0.23.0/index.js"
+                    }
+                }
+            }
+        </script>
+        <!-- Import maps polyfill for browsers without import maps support (e.g. Safari 16.3) -->
+        <script async src="https://ga.jspm.io/npm:es-module-shims@2.6.2/dist/es-module-shims.js" crossorigin="anonymous"></script>
+        <!-- Use Babel for JSX in <script> tags -->
+        <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+        <!-- Polyfills for older browsers -->
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <script type="text/babel" data-type="module">
+            import * as React from 'react';
+            import { createRoot } from 'react-dom/client';
+            import * as THEOplayerReactUI from '@theoplayer/react-ui';
+            import { useDeviceTypeFromParent, useSourceFromParent } from '../utils.js';
+
+            const configuration = {
+                /**
+                 * libraryLocation: For demonstration purposes, we use the free unpkg.com CDN.
+                 * For production use, we recommend hosting THEOplayer yourself
+                 * and changing this (as well as the <script> and <link> tags above)
+                 * to point to THEOplayer's location on your own website.
+                 */
+                libraryLocation: 'https://cdn.theoplayer.com/dash/theoplayer/',
+                /**
+                 * licenseUrl: Change this to point to your THEOplayer license file.
+                 * Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+                 */
+                licenseUrl: '../../../../../theoplayer-license.txt'
+            };
+
+            const defaultSource = {
+                sources: { src: 'https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8' },
+                metadata: {
+                    title: 'Big Buck Bunny'
+                },
+                textTracks: [
+                    {
+                        default: true,
+                        src: 'https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt',
+                        label: 'thumbnails',
+                        kind: 'metadata'
+                    }
+                ]
+            };
+
+            const App = () => {
+                const source = useSourceFromParent() || defaultSource;
+                const deviceType = useDeviceTypeFromParent() || null;
+                const title = source.metadata.title;
+                return (
+                    <THEOplayerReactUI.DefaultUI
+                        configuration={configuration}
+                        source={source}
+                        device-type={deviceType}
+                        title={<span>{title}</span>}
+                    />
+                );
+            };
+
+            const root = createRoot(document.getElementById('app'));
+            root.render(<App />);
+        </script>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/react/text-tracks/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/text-tracks/demo.html
@@ -57,8 +57,8 @@
         <script type="importmap">
             {
                 "imports": {
-                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
-                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.3.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/dist/THEOplayerUI.mjs",
                     "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
                     "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
                     "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
@@ -85,7 +85,7 @@
         <!-- Use Babel for JSX in <script> tags -->
         <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
         <!-- Polyfills for older browsers -->
-        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.3.1/polyfills"></script>
     </head>
     <body>
         <div id="app"></div>

--- a/docs/static/open-video-ui/v2/examples/react/text-tracks/demo.html
+++ b/docs/static/open-video-ui/v2/examples/react/text-tracks/demo.html
@@ -1,0 +1,320 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Text Tracks with React</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                background: #000;
+            }
+
+            theoplayer-ui {
+                font-family: 'Noto Sans', sans-serif;
+                width: 100%;
+            }
+
+            .my-title {
+                color: white;
+                padding: 10px;
+                font-size: 14px;
+                line-height: 24px;
+            }
+
+            .my-menu-table {
+                display: grid;
+                grid-template-columns: max-content 1fr;
+            }
+
+            .my-menu-table > * {
+                align-self: center;
+                font-size: 14px;
+                line-height: 24px;
+                padding: 10px;
+            }
+
+            .my-menu-table > span {
+                display: block;
+            }
+        </style>
+        <!--
+          JSPM Generator Import Map
+          Edit URL: https://generator.jspm.io/#VYxLDkBAEAV7IW5iqRkR7PQlHMCnE5M0I6NF3J4gEduqei8KAMK6mdWq8AAkVhPPba9kMMUcSEd2i7QH+4fHm71UidlP7dx94ukGN5GpMMM06cXyrPD+3gy+MRVo7mr0bmLhdT0BSwPyx5UA
+        -->
+        <script type="importmap">
+            {
+                "imports": {
+                    "@theoplayer/react-ui": "https://ga.jspm.io/npm:@theoplayer/react-ui@2.1.1/dist/THEOplayerReactUI.mjs",
+                    "@theoplayer/web-ui": "https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/dist/THEOplayerUI.mjs",
+                    "lit": "https://ga.jspm.io/npm:lit@3.3.1/index.js",
+                    "lit/decorators.js": "https://ga.jspm.io/npm:lit@3.3.1/decorators.js",
+                    "lit/directives/": "https://ga.jspm.io/npm:lit@3.3.1/directives/",
+                    "@lit/react": "https://ga.jspm.io/npm:@lit/react@1.0.4/index.js",
+                    "react": "https://ga.jspm.io/npm:react@18.2.0/index.js",
+                    "react-dom/client": "https://ga.jspm.io/npm:react-dom@18.2.0/client.js",
+                    "theoplayer/chromeless": "https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.chromeless.esm.js"
+                },
+                "scopes": {
+                    "https://ga.jspm.io/": {
+                        "@lit/reactive-element": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/reactive-element.js",
+                        "@lit/reactive-element/decorators/": "https://ga.jspm.io/npm:@lit/reactive-element@2.1.1/decorators/",
+                        "lit-element/lit-element.js": "https://ga.jspm.io/npm:lit-element@4.2.1/lit-element.js",
+                        "lit-html": "https://ga.jspm.io/npm:lit-html@3.3.1/lit-html.js",
+                        "lit-html/": "https://ga.jspm.io/npm:lit-html@3.3.1/",
+                        "react-dom": "https://ga.jspm.io/npm:react-dom@18.2.0/index.js",
+                        "scheduler": "https://ga.jspm.io/npm:scheduler@0.23.0/index.js"
+                    }
+                }
+            }
+        </script>
+        <!-- Import maps polyfill for browsers without import maps support (e.g. Safari 16.3) -->
+        <script async src="https://ga.jspm.io/npm:es-module-shims@2.6.2/dist/es-module-shims.js" crossorigin="anonymous"></script>
+        <!-- Use Babel for JSX in <script> tags -->
+        <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+        <!-- Polyfills for older browsers -->
+        <script nomodule src="https://ga.jspm.io/npm:@theoplayer/web-ui@2.1.1/polyfills"></script>
+    </head>
+    <body>
+        <div id="app"></div>
+
+        <script type="text/babel" data-type="module">
+            import * as React from 'react';
+            import { useContext, useEffect, useState } from 'react';
+            import { createRoot } from 'react-dom/client';
+            import * as THEOplayerReactUI from '@theoplayer/react-ui';
+            import { useDeviceTypeFromParent, useSourceFromParent } from '../utils.js';
+
+            const configuration = {
+                /**
+                 * libraryLocation: For demonstration purposes, we use the free unpkg.com CDN.
+                 * For production use, we recommend hosting THEOplayer yourself
+                 * and changing this (as well as the <script> and <link> tags above)
+                 * to point to THEOplayer's location on your own website.
+                 */
+                libraryLocation: 'https://cdn.theoplayer.com/dash/theoplayer/',
+                /**
+                 * licenseUrl: Change this to point to your THEOplayer license file.
+                 * Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+                 */
+                licenseUrl: '../../../../../theoplayer-license.txt'
+            };
+
+            // Elephant's Dream has in-stream subtitle tracks (Chinese & French) and multiple audio tracks.
+            const defaultSource = {
+                sources: { src: 'https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8' },
+                metadata: {
+                    title: "Elephant's Dream"
+                }
+            };
+
+            // Returns whether the player has (previously) started playback for this stream.
+            // Can be used to show/hide certain initial controls, such as a poster image or a centered play button.
+            const useFirstPlay = () => {
+                const source = THEOplayerReactUI.useSource();
+                const paused = THEOplayerReactUI.usePaused();
+                const [firstPlay, setFirstPlay] = useState(false);
+
+                // https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+                const [prevSource, setPrevSource] = useState(source);
+                if (source !== prevSource) {
+                    setPrevSource(source);
+                    setFirstPlay(false);
+                }
+                if (!firstPlay && !paused) {
+                    setFirstPlay(true);
+                }
+
+                return firstPlay;
+            };
+
+            const ShowOnFirstPlay = ({ children }) => {
+                const firstPlay = useFirstPlay();
+                return firstPlay ? children : null;
+            };
+
+            const HideOnFirstPlay = ({ children }) => {
+                const firstPlay = useFirstPlay();
+                return firstPlay ? null : children;
+            };
+
+            const Spacer = () => {
+                const styles = { flexGrow: 1 };
+                return <span style={styles}></span>;
+            };
+
+            // A hook returning the player's subtitle text tracks.
+            const useSubtitleTracks = () => {
+                const player = useContext(THEOplayerReactUI.PlayerContext);
+                const [tracks, setTracks] = useState([]);
+
+                useEffect(() => {
+                    if (!player) return;
+                    const textTracks = player.textTracks;
+                    const update = () => {
+                        setTracks(textTracks.filter((track) => track.kind === 'subtitles' || track.kind === 'captions'));
+                    };
+                    update();
+                    textTracks.addEventListener(['addtrack', 'removetrack'], update);
+                    return () => textTracks.removeEventListener(['addtrack', 'removetrack'], update);
+                }, [player]);
+
+                return { player, tracks };
+            };
+
+            // A subtitle picker built from the low-level TextTrackOffRadioButton and TextTrackRadioButton.
+            // In practice, prefer <TrackRadioGroup trackType="subtitles" show-off />, which composes these for you.
+            const CustomSubtitlePicker = () => {
+                const { player, tracks } = useSubtitleTracks();
+                return (
+                    <THEOplayerReactUI.RadioGroup>
+                        <THEOplayerReactUI.TextTrackOffRadioButton trackList={player?.textTracks} />
+                        {tracks.map((track) => (
+                            <THEOplayerReactUI.TextTrackRadioButton key={track.uid} track={track} />
+                        ))}
+                    </THEOplayerReactUI.RadioGroup>
+                );
+            };
+
+            const FONT_COLORS = [
+                { label: 'Default', value: '' },
+                { label: 'White', value: 'rgb(255,255,255)' },
+                { label: 'Yellow', value: 'rgb(255,255,0)' },
+                { label: 'Green', value: 'rgb(0,255,0)' },
+                { label: 'Cyan', value: 'rgb(0,255,255)' },
+                { label: 'Blue', value: 'rgb(0,0,255)' },
+                { label: 'Magenta', value: 'rgb(255,0,255)' },
+                { label: 'Red', value: 'rgb(255,0,0)' },
+                { label: 'Black', value: 'rgb(0,0,0)' }
+            ];
+
+            // A custom player UI demonstrating text track components.
+            const MyTextTracksUI = ({ configuration, source, deviceType, title }) => {
+                return (
+                    <THEOplayerReactUI.UIContainer
+                        configuration={configuration}
+                        source={source}
+                        device-type={deviceType}
+                        onReady={(player) => {
+                            console.log('THEOplayer is ready!', player);
+                        }}
+                        topChrome={
+                            <ShowOnFirstPlay>
+                                <THEOplayerReactUI.ControlBar>
+                                    <span className="my-title">{title}</span>
+                                </THEOplayerReactUI.ControlBar>
+                            </ShowOnFirstPlay>
+                        }
+                        centeredChrome={
+                            <HideOnFirstPlay>
+                                <THEOplayerReactUI.PlayButton />
+                            </HideOnFirstPlay>
+                        }
+                        centeredLoading={
+                            <ShowOnFirstPlay>
+                                <THEOplayerReactUI.LoadingIndicator />
+                            </ShowOnFirstPlay>
+                        }
+                        bottomChrome={
+                            <ShowOnFirstPlay>
+                                <THEOplayerReactUI.ControlBar>
+                                    <THEOplayerReactUI.TimeRange />
+                                </THEOplayerReactUI.ControlBar>
+                                <THEOplayerReactUI.ControlBar>
+                                    <THEOplayerReactUI.PlayButton />
+                                    <THEOplayerReactUI.MuteButton />
+                                    <THEOplayerReactUI.VolumeRange />
+                                    <THEOplayerReactUI.TimeDisplay />
+                                    <Spacer />
+                                    <THEOplayerReactUI.LanguageMenuButton menu="language-menu" />
+                                    <THEOplayerReactUI.MenuButton menu="settings-menu">CC</THEOplayerReactUI.MenuButton>
+                                    <THEOplayerReactUI.FullscreenButton />
+                                </THEOplayerReactUI.ControlBar>
+                            </ShowOnFirstPlay>
+                        }
+                        menu={
+                            <>
+                                <THEOplayerReactUI.LanguageMenu id="language-menu" />
+                                <THEOplayerReactUI.MenuGroup id="settings-menu">
+                                    <THEOplayerReactUI.Menu heading="Subtitles & captions">
+                                        <div className="my-menu-table">
+                                            <span>Subtitles</span>
+                                            <THEOplayerReactUI.MenuButton menu="subtitle-menu">
+                                                <span>Select</span>
+                                            </THEOplayerReactUI.MenuButton>
+                                            <span>Subtitles (custom)</span>
+                                            <THEOplayerReactUI.MenuButton menu="subtitle-custom-menu">
+                                                <span>Select</span>
+                                            </THEOplayerReactUI.MenuButton>
+                                            <span>Subtitle appearance</span>
+                                            <THEOplayerReactUI.MenuButton menu="subtitle-style-menu">
+                                                <THEOplayerReactUI.TextTrackStyleDisplay property="fontColor" />
+                                            </THEOplayerReactUI.MenuButton>
+                                            <span>Font color (custom)</span>
+                                            <THEOplayerReactUI.MenuButton menu="font-color-menu">
+                                                <THEOplayerReactUI.TextTrackStyleDisplay property="fontColor" />
+                                            </THEOplayerReactUI.MenuButton>
+                                        </div>
+                                    </THEOplayerReactUI.Menu>
+
+                                    {/* Idiomatic subtitle picker using TrackRadioGroup. */}
+                                    <THEOplayerReactUI.Menu id="subtitle-menu" closeOnInput hidden heading="Subtitles">
+                                        <THEOplayerReactUI.TrackRadioGroup trackType="subtitles" show-off />
+                                    </THEOplayerReactUI.Menu>
+
+                                    {/* Manual subtitle picker using TextTrackOffRadioButton and TextTrackRadioButton. */}
+                                    <THEOplayerReactUI.Menu id="subtitle-custom-menu" closeOnInput hidden heading="Subtitles (custom)">
+                                        <CustomSubtitlePicker />
+                                    </THEOplayerReactUI.Menu>
+
+                                    {/* Pre-built subtitle style menu. */}
+                                    <THEOplayerReactUI.TextTrackStyleMenu
+                                        id="subtitle-style-menu"
+                                        closeOnInput
+                                        hidden
+                                        heading="Subtitle appearance"
+                                    />
+
+                                    {/* Manual font color submenu using TextTrackStyleRadioGroup and TextTrackStyleResetButton. */}
+                                    <THEOplayerReactUI.Menu id="font-color-menu" closeOnInput hidden heading="Font color (custom)">
+                                        <THEOplayerReactUI.TextTrackStyleResetButton slot="heading" />
+                                        <THEOplayerReactUI.TextTrackStyleRadioGroup property="fontColor">
+                                            {FONT_COLORS.map(({ label, value }) => (
+                                                <THEOplayerReactUI.RadioButton key={value} value={value}>
+                                                    {label}
+                                                </THEOplayerReactUI.RadioButton>
+                                            ))}
+                                        </THEOplayerReactUI.TextTrackStyleRadioGroup>
+                                    </THEOplayerReactUI.Menu>
+                                </THEOplayerReactUI.MenuGroup>
+                            </>
+                        }
+                        error={<THEOplayerReactUI.ErrorDisplay />}
+                    />
+                );
+            };
+
+            const App = () => {
+                const source = useSourceFromParent() || defaultSource;
+                const deviceType = useDeviceTypeFromParent() || null;
+                const title = source.metadata.title;
+                return <MyTextTracksUI configuration={configuration} source={source} deviceType={deviceType} title={title} />;
+            };
+
+            const root = createRoot(document.getElementById('app'));
+            root.render(<App />);
+        </script>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/react/utils.js
+++ b/docs/static/open-video-ui/v2/examples/react/utils.js
@@ -5,6 +5,7 @@ import { useSyncExternalStore } from 'react';
 
 let source = null;
 let deviceType = null;
+let language = null;
 const listeners = [];
 
 function subscribe(cb) {
@@ -23,6 +24,8 @@ function subscribe(cb) {
  *   Overrides the player's device type.
  * - `{ type: "source", source: SourceDescription }`
  *   Changes the player's source.
+ * - `{ type: "language", language: string }`
+ *   Sets the UI language.
  */
 window.addEventListener('message', (event) => {
     if (event.origin !== location.origin) return;
@@ -36,6 +39,11 @@ window.addEventListener('message', (event) => {
         }
         case 'source': {
             source = data.source;
+            listeners.forEach((listener) => listener());
+            break;
+        }
+        case 'language': {
+            language = data.language;
             listeners.forEach((listener) => listener());
             break;
         }
@@ -60,6 +68,17 @@ export function useSourceFromParent() {
     return useSyncExternalStore(
         subscribe,
         () => source,
+        () => undefined
+    );
+}
+
+/**
+ * Returns the UI language given by the <iframe>'s parent window (if any).
+ */
+export function useLanguageFromParent() {
+    return useSyncExternalStore(
+        subscribe,
+        () => language,
         () => undefined
     );
 }

--- a/docs/static/open-video-ui/v2/examples/web/custom-play-button/demo.html
+++ b/docs/static/open-video-ui/v2/examples/web/custom-play-button/demo.html
@@ -1,0 +1,121 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Custom play button</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+            }
+
+            theoplayer-ui {
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                font-family: 'Noto Sans', sans-serif;
+                background: #000;
+            }
+
+            .spacer {
+                flex-grow: 1;
+            }
+
+            .bottom-chrome {
+                position: relative;
+                display: flex;
+                flex-flow: column nowrap;
+                align-items: stretch;
+            }
+
+            /* The play button. */
+            .big-play {
+                color: #fff;
+                background: rgba(124, 58, 237, 0.45);
+                backdrop-filter: blur(6px);
+                border-radius: 50%;
+                padding: 32px;
+                box-shadow: 0 4px 20px rgba(124, 58, 237, 0.4);
+                transition:
+                    transform 0.4s ease,
+                    box-shadow 0.4s ease,
+                    background 0.4s ease;
+            }
+
+            .big-play svg {
+                width: 64px;
+                height: 64px;
+            }
+
+            .big-play:hover {
+                background: rgba(139, 92, 246, 0.55);
+                animation: pulse 3s ease-in-out infinite;
+            }
+
+            @keyframes pulse {
+                0%,
+                100% {
+                    transform: scale(1);
+                    box-shadow: 0 4px 20px rgba(124, 58, 237, 0.35);
+                }
+                50% {
+                    transform: scale(1.06);
+                    box-shadow: 0 6px 26px rgba(124, 58, 237, 0.6);
+                }
+            }
+        </style>
+        <script src="https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.js"></script>
+        <script nomodule src="https://unpkg.com/@theoplayer/web-ui@2/polyfills"></script>
+        <script async src="https://unpkg.com/@theoplayer/web-ui@2"></script>
+        <script async src="../utils.js"></script>
+    </head>
+    <body>
+        <!--
+            libraryLocation: For demonstration purposes, we use the theoplayer.com CDN.
+            For production use, we recommend hosting THEOplayer yourself
+            and changing this (as well as the <script> and <link> tags above)
+            to point to THEOplayer's location on your own website.
+
+            licenseUrl: Change this to point to your THEOplayer license file.
+            Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+        -->
+        <theoplayer-ui
+            configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"}}'
+        >
+            <theoplayer-loading-indicator slot="centered-loading" no-auto-hide></theoplayer-loading-indicator>
+            <div slot="centered-chrome">
+                <!-- Override the play/pause icons through the named slots. -->
+                <theoplayer-play-button class="big-play">
+                    <svg slot="play-icon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor"><path d="M8 5v14l11-7z"></path></svg>
+                    <svg slot="pause-icon" viewBox="0 0 24 24" width="28" height="28" fill="currentColor">
+                        <path d="M6 5h4v14H6zM14 5h4v14h-4z"></path>
+                    </svg>
+                </theoplayer-play-button>
+            </div>
+            <div class="bottom-chrome">
+                <theoplayer-control-bar>
+                    <theoplayer-time-range></theoplayer-time-range>
+                </theoplayer-control-bar>
+                <theoplayer-control-bar>
+                    <theoplayer-play-button></theoplayer-play-button>
+                    <theoplayer-mute-button></theoplayer-mute-button>
+                    <theoplayer-volume-range></theoplayer-volume-range>
+                    <theoplayer-time-display show-duration></theoplayer-time-display>
+                    <span class="spacer"></span>
+                    <theoplayer-fullscreen-button></theoplayer-fullscreen-button>
+                </theoplayer-control-bar>
+            </div>
+            <theoplayer-error-display slot="error"></theoplayer-error-display>
+        </theoplayer-ui>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/web/localization/demo.html
+++ b/docs/static/open-video-ui/v2/examples/web/localization/demo.html
@@ -1,0 +1,85 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Localization</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-default-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+            }
+
+            theoplayer-default-ui {
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                font-family: 'Noto Sans', sans-serif;
+                background: #000;
+            }
+        </style>
+        <script src="https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.js"></script>
+        <script nomodule src="https://unpkg.com/@theoplayer/web-ui@2/polyfills"></script>
+        <script async src="https://unpkg.com/@theoplayer/web-ui@2"></script>
+        <script async src="../utils.js"></script>
+    </head>
+    <body>
+        <!--
+            libraryLocation: For demonstration purposes, we use the theoplayer.com CDN.
+            For production use, we recommend hosting THEOplayer yourself
+            and changing this (as well as the <script> and <link> tags above)
+            to point to THEOplayer's location on your own website.
+
+            licenseUrl: Change this to point to your THEOplayer license file.
+            Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+        -->
+        <theoplayer-default-ui
+            id="ui"
+            lang="en"
+            configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"}}'
+        ></theoplayer-default-ui>
+
+        <script>
+            // Register the Dutch locale.
+            customElements.whenDefined('theoplayer-default-ui').then(() => {
+                THEOplayerUI.addLocale('nl', {
+                    playAria: 'afspelen',
+                    pauseAria: 'pauzeren',
+                    replayAria: 'opnieuw afspelen',
+                    muteAria: 'dempen',
+                    unmuteAria: 'dempen opheffen',
+                    volumeAria: 'volume',
+                    seekAria: 'zoeken',
+                    seekForwardAria: (offset) => `spring voorwaarts met ${offset}`,
+                    seekBackwardAria: (offset) => `spring achterwaarts met ${offset}`,
+                    live: 'LIVE',
+                    seekToLiveAria: 'spring naar live',
+                    fullscreenAria: 'volledig scherm',
+                    fullscreenExitAria: 'volledig scherm sluiten',
+                    closeMenuAria: 'menu sluiten',
+                    openLanguageMenuAria: 'taalmenu openen',
+                    languageMenuHeading: 'Taal',
+                    audioMenuHeading: 'Audio',
+                    subtitleMenuHeading: 'Ondertitels',
+                    subtitleOff: 'Uit',
+                    openSettingsMenuAria: 'instellingenmenu openen',
+                    settingsMenuHeading: 'Instellingen',
+                    qualityMenuHeading: 'Kwaliteit',
+                    playbackRateMenuHeading: 'Afspeelsnelheid',
+                    formatPlaybackRate: (rate) => (rate === 1 ? 'Normaal' : `${rate}x`),
+                    automaticQualityLabel: 'Automatisch',
+                    errorHeading: 'Er is een fout opgetreden'
+                });
+            });
+        </script>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/web/modern/demo.html
+++ b/docs/static/open-video-ui/v2/examples/web/modern/demo.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Modern UI</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+            }
+
+            theoplayer-ui {
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                font-family: 'Noto Sans', sans-serif;
+                background: #000;
+
+                --theoplayer-range-bar-color: #a855f7;
+                --theoplayer-range-thumb-background: radial-gradient(circle, #c084fc, #7c3aed);
+                --theoplayer-control-background-gradient-stops: transparent 0%, rgba(46, 16, 101, 0.85) 100%;
+            }
+
+            .title {
+                user-select: none;
+                color: #fff;
+                text-shadow: 0 0 4px rgba(0, 0, 0, 0.75);
+                font-size: 14px;
+                line-height: 24px;
+                padding: 10px;
+            }
+
+            .spacer {
+                flex-grow: 1;
+            }
+
+            .bottom-chrome {
+                position: relative;
+                display: flex;
+                flex-flow: column nowrap;
+                align-items: stretch;
+            }
+
+            .bottom-row {
+                display: flex;
+                flex-flow: row nowrap;
+                align-items: center;
+                gap: 8px;
+                padding: 0 8px 8px;
+            }
+
+            .pill {
+                display: inline-flex;
+                align-items: center;
+                border-radius: 999px;
+                background: linear-gradient(135deg, rgba(109, 40, 217, 0.55), rgba(168, 85, 247, 0.45));
+                backdrop-filter: blur(3px);
+            }
+
+            .bottom-row .pill {
+                height: 44px;
+            }
+
+            .volume {
+                display: inline-flex;
+                align-items: center;
+            }
+
+            .volume-slider {
+                display: inline-flex;
+                align-items: center;
+                width: 0;
+                overflow: hidden;
+                transition: width 0.2s ease;
+            }
+
+            .volume:hover .volume-slider {
+                width: 100px;
+            }
+
+            .center-pill {
+                padding: 4px 10px;
+                gap: 8px;
+            }
+
+            .center-pill * {
+                --theoplayer-control-height: 48px;
+            }
+        </style>
+        <script src="https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.js"></script>
+        <script nomodule src="https://unpkg.com/@theoplayer/web-ui@2/polyfills"></script>
+        <script async src="https://unpkg.com/@theoplayer/web-ui@2"></script>
+        <script async src="../utils.js"></script>
+    </head>
+    <body>
+        <!--
+            libraryLocation: For demonstration purposes, we use the theoplayer.com CDN.
+            For production use, we recommend hosting THEOplayer yourself
+            and changing this (as well as the <script> and <link> tags above)
+            to point to THEOplayer's location on your own website.
+
+            licenseUrl: Change this to point to your THEOplayer license file.
+            Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+        -->
+        <theoplayer-ui
+            configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"}}'
+        >
+            <theoplayer-control-bar slot="top-chrome">
+                <span class="title">Big Buck Bunny</span>
+                <span class="spacer"></span>
+            </theoplayer-control-bar>
+            <theoplayer-loading-indicator slot="centered-loading" no-auto-hide></theoplayer-loading-indicator>
+            <div slot="centered-chrome">
+                <div class="pill center-pill">
+                    <theoplayer-seek-button seek-offset="-10"></theoplayer-seek-button>
+                    <theoplayer-play-button></theoplayer-play-button>
+                    <theoplayer-seek-button seek-offset="10"></theoplayer-seek-button>
+                </div>
+            </div>
+            <div class="bottom-chrome">
+                <theoplayer-control-bar>
+                    <theoplayer-time-range></theoplayer-time-range>
+                </theoplayer-control-bar>
+                <div class="bottom-row">
+                    <span class="pill">
+                        <theoplayer-play-button></theoplayer-play-button>
+                        <span class="volume">
+                            <theoplayer-mute-button></theoplayer-mute-button>
+                            <span class="volume-slider">
+                                <theoplayer-volume-range></theoplayer-volume-range>
+                            </span>
+                        </span>
+                        <theoplayer-time-display show-duration></theoplayer-time-display>
+                    </span>
+                    <span class="spacer"></span>
+                    <span class="pill">
+                        <theoplayer-language-menu-button menu="language-menu"></theoplayer-language-menu-button>
+                        <theoplayer-fullscreen-button></theoplayer-fullscreen-button>
+                    </span>
+                </div>
+            </div>
+            <theoplayer-language-menu id="language-menu" slot="menu" hidden></theoplayer-language-menu>
+            <theoplayer-error-display slot="error"></theoplayer-error-display>
+        </theoplayer-ui>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/web/remove-controls/demo.html
+++ b/docs/static/open-video-ui/v2/examples/web/remove-controls/demo.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Removing controls</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-default-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+            }
+
+            theoplayer-default-ui {
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                font-family: 'Noto Sans', sans-serif;
+                background: #000;
+            }
+
+            /* Hide the seek bar by targeting its shadow part. */
+            theoplayer-default-ui::part(time-range) {
+                display: none;
+            }
+        </style>
+        <script src="https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.js"></script>
+        <script nomodule src="https://unpkg.com/@theoplayer/web-ui@2/polyfills"></script>
+        <script async src="https://unpkg.com/@theoplayer/web-ui@2"></script>
+        <script async src="../utils.js"></script>
+    </head>
+    <body>
+        <!--
+            libraryLocation: For demonstration purposes, we use the theoplayer.com CDN.
+            For production use, we recommend hosting THEOplayer yourself
+            and changing this (as well as the <script> and <link> tags above)
+            to point to THEOplayer's location on your own website.
+
+            licenseUrl: Change this to point to your THEOplayer license file.
+            Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+        -->
+        <theoplayer-default-ui
+            configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/big_buck_bunny/big_buck_bunny.m3u8"},"metadata":{"title":"Big Buck Bunny"},"textTracks":[{"default":true,"src":"https://cdn.theoplayer.com/video/big_buck_bunny/thumbnails.vtt","label":"thumbnails","kind":"metadata"}]}'
+        ></theoplayer-default-ui>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/web/text-tracks/demo.html
+++ b/docs/static/open-video-ui/v2/examples/web/text-tracks/demo.html
@@ -1,0 +1,220 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>Text Tracks</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" />
+        <style>
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+            }
+
+            theoplayer-ui:not(:defined) {
+                display: inline-block;
+                box-sizing: border-box;
+            }
+
+            theoplayer-ui {
+                width: 100%;
+                aspect-ratio: 16 / 9;
+                font-family: 'Noto Sans', sans-serif;
+                background: #000;
+            }
+
+            .spacer {
+                flex-grow: 1;
+            }
+
+            .title {
+                user-select: none;
+                color: var(--theoplayer-text-color, #fff);
+                text-shadow: 0 0 4px rgba(0, 0, 0, 0.75);
+                font-size: var(--theoplayer-text-font-size, 14px);
+                line-height: var(--theoplayer-text-content-height, var(--theoplayer-control-height, 24px));
+                padding: var(--theoplayer-control-padding, 10px);
+            }
+
+            .centered-chrome * {
+                --theoplayer-control-height: 48px;
+            }
+
+            .bottom-chrome {
+                position: relative;
+                display: flex;
+                flex-flow: column nowrap;
+                align-items: stretch;
+            }
+
+            .my-menu-table {
+                border-collapse: collapse;
+            }
+
+            .my-menu-table td {
+                font-size: 14px;
+                line-height: 24px;
+                padding: 5px 10px;
+            }
+
+            theoplayer-ui:not([has-first-play]) theoplayer-control-bar,
+            theoplayer-ui:not([has-first-play]) .centered-chrome :not(theoplayer-play-button) {
+                display: none !important;
+            }
+
+            theoplayer-ui[has-first-play]:not([mobile]) .centered-chrome theoplayer-play-button {
+                display: none !important;
+            }
+        </style>
+        <script src="https://cdn.theoplayer.com/dash/theoplayer/THEOplayer.js"></script>
+        <script nomodule src="https://unpkg.com/@theoplayer/web-ui@2/polyfills"></script>
+        <script async src="https://unpkg.com/@theoplayer/web-ui@2"></script>
+        <script async src="../utils.js"></script>
+    </head>
+    <body>
+        <!--
+            libraryLocation: For demonstration purposes, we use the theoplayer.com CDN.
+            For production use, we recommend hosting THEOplayer yourself
+            and changing this (as well as the <script> and <link> tags above)
+            to point to THEOplayer's location on your own website.
+
+            licenseUrl: Change this to point to your THEOplayer license file.
+            Alternatively, replace it with a "license" property whose value is your THEOplayer license itself.
+        -->
+        <theoplayer-ui
+            configuration='{"libraryLocation":"https://cdn.theoplayer.com/dash/theoplayer/","licenseUrl":"../../../../../theoplayer-license.txt"}'
+            source='{"sources":{"src":"https://cdn.theoplayer.com/video/elephants-dream/playlist.m3u8"},"metadata":{"title":"Elephant&apos;s Dream"}}'
+        >
+            <theoplayer-control-bar slot="top-chrome">
+                <span class="title">Elephant's Dream</span>
+                <span class="spacer"></span>
+            </theoplayer-control-bar>
+            <theoplayer-loading-indicator slot="centered-loading" no-auto-hide></theoplayer-loading-indicator>
+            <div slot="centered-chrome" class="centered-chrome">
+                <theoplayer-play-button></theoplayer-play-button>
+            </div>
+            <div class="bottom-chrome">
+                <theoplayer-control-bar>
+                    <theoplayer-time-range></theoplayer-time-range>
+                </theoplayer-control-bar>
+                <theoplayer-control-bar>
+                    <theoplayer-play-button mobile-hidden></theoplayer-play-button>
+                    <theoplayer-mute-button></theoplayer-mute-button>
+                    <theoplayer-volume-range mobile-hidden></theoplayer-volume-range>
+                    <theoplayer-time-display show-duration></theoplayer-time-display>
+                    <span class="spacer"></span>
+                    <theoplayer-language-menu-button menu="language-menu"></theoplayer-language-menu-button>
+                    <theoplayer-menu-button menu="settings-menu">CC</theoplayer-menu-button>
+                    <theoplayer-fullscreen-button></theoplayer-fullscreen-button>
+                </theoplayer-control-bar>
+            </div>
+
+            <!-- The default language menu, which bundles audio + subtitle selection and the subtitle style menu. -->
+            <theoplayer-language-menu id="language-menu" slot="menu" hidden></theoplayer-language-menu>
+
+            <!-- A custom settings menu demonstrating the individual text track components. -->
+            <theoplayer-menu-group id="settings-menu" slot="menu" hidden>
+                <theoplayer-menu>
+                    <span slot="heading">Subtitles &amp; captions</span>
+                    <table class="my-menu-table">
+                        <tr>
+                            <td>Subtitles</td>
+                            <td>
+                                <theoplayer-menu-button menu="subtitle-menu"><span>Select</span></theoplayer-menu-button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Subtitles (custom)</td>
+                            <td>
+                                <theoplayer-menu-button menu="subtitle-custom-menu"><span>Select</span></theoplayer-menu-button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Subtitle appearance</td>
+                            <td>
+                                <theoplayer-menu-button menu="subtitle-style-menu">
+                                    <theoplayer-text-track-style-display property="fontColor"></theoplayer-text-track-style-display>
+                                </theoplayer-menu-button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Font color (custom)</td>
+                            <td>
+                                <theoplayer-menu-button menu="font-color-menu">
+                                    <theoplayer-text-track-style-display property="fontColor"></theoplayer-text-track-style-display>
+                                </theoplayer-menu-button>
+                            </td>
+                        </tr>
+                    </table>
+                </theoplayer-menu>
+
+                <!-- Idiomatic subtitle picker: composes TextTrackOffRadioButton + TextTrackRadioButton. -->
+                <theoplayer-menu id="subtitle-menu" menu-close-on-input hidden>
+                    <span slot="heading">Subtitles</span>
+                    <theoplayer-track-radio-group track-type="subtitles" show-off></theoplayer-track-radio-group>
+                </theoplayer-menu>
+
+                <!-- Manual subtitle picker, populated from the player's text tracks (see script below). -->
+                <theoplayer-menu id="subtitle-custom-menu" menu-close-on-input hidden>
+                    <span slot="heading">Subtitles (custom)</span>
+                    <theoplayer-radio-group id="custom-subtitle-group"></theoplayer-radio-group>
+                </theoplayer-menu>
+
+                <!-- Pre-built subtitle style menu: composes TextTrackStyleDisplay, TextTrackStyleRadioGroup and TextTrackStyleResetButton. -->
+                <theoplayer-text-track-style-menu id="subtitle-style-menu" menu-close-on-input hidden>
+                    <span slot="heading">Subtitle appearance</span>
+                </theoplayer-text-track-style-menu>
+
+                <!-- Manual font color submenu, built from TextTrackStyleRadioGroup + TextTrackStyleResetButton. -->
+                <theoplayer-menu id="font-color-menu" menu-close-on-input hidden>
+                    <theoplayer-text-track-style-reset-button slot="heading"></theoplayer-text-track-style-reset-button>
+                    <span slot="heading">Font color (custom)</span>
+                    <theoplayer-text-track-style-radio-group property="fontColor">
+                        <theoplayer-radio-button value="">Default</theoplayer-radio-button>
+                        <theoplayer-radio-button value="rgb(255,255,255)">White</theoplayer-radio-button>
+                        <theoplayer-radio-button value="rgb(255,255,0)">Yellow</theoplayer-radio-button>
+                        <theoplayer-radio-button value="rgb(0,255,0)">Green</theoplayer-radio-button>
+                        <theoplayer-radio-button value="rgb(0,255,255)">Cyan</theoplayer-radio-button>
+                        <theoplayer-radio-button value="rgb(0,0,255)">Blue</theoplayer-radio-button>
+                        <theoplayer-radio-button value="rgb(255,0,255)">Magenta</theoplayer-radio-button>
+                        <theoplayer-radio-button value="rgb(255,0,0)">Red</theoplayer-radio-button>
+                        <theoplayer-radio-button value="rgb(0,0,0)">Black</theoplayer-radio-button>
+                    </theoplayer-text-track-style-radio-group>
+                </theoplayer-menu>
+            </theoplayer-menu-group>
+
+            <theoplayer-error-display slot="error"></theoplayer-error-display>
+        </theoplayer-ui>
+
+        <script>
+            // Populate the "Subtitles (custom)" menu from the player's subtitle tracks,
+            // demonstrating the low-level <theoplayer-text-track-off-radio-button> and
+            // <theoplayer-text-track-radio-button> components. In practice, prefer
+            // <theoplayer-track-radio-group track-type="subtitles" show-off>, which composes these for you.
+            const ui = document.querySelector('theoplayer-ui');
+            const group = document.getElementById('custom-subtitle-group');
+            ui.addEventListener('theoplayerready', () => {
+                const textTracks = ui.player.textTracks;
+                const rebuild = () => {
+                    group.replaceChildren();
+                    const off = document.createElement('theoplayer-text-track-off-radio-button');
+                    off.trackList = textTracks;
+                    group.appendChild(off);
+                    for (const track of textTracks) {
+                        if (track.kind === 'subtitles' || track.kind === 'captions') {
+                            const button = document.createElement('theoplayer-text-track-radio-button');
+                            button.track = track;
+                            group.appendChild(button);
+                        }
+                    }
+                };
+                rebuild();
+                textTracks.addEventListener('addtrack', rebuild);
+                textTracks.addEventListener('removetrack', rebuild);
+            });
+        </script>
+    </body>
+</html>

--- a/docs/static/open-video-ui/v2/examples/web/utils.js
+++ b/docs/static/open-video-ui/v2/examples/web/utils.js
@@ -12,6 +12,8 @@
  *   Changes the player's source.
  * - `{ type: "style", style: string }`
  *   Updates the custom CSS style.
+ * - `{ type: "language", language: string }`
+ *   Sets the UI language (the `lang` attribute).
  */
 window.addEventListener('message', (event) => {
     if (event.origin !== location.origin) return;
@@ -35,6 +37,11 @@ window.addEventListener('message', (event) => {
             if (styleEl) {
                 styleEl.textContent = data.style;
             }
+            break;
+        }
+        case 'language': {
+            const ui = document.querySelector('theoplayer-default-ui, theoplayer-ui');
+            ui?.setAttribute('lang', data.language);
             break;
         }
     }


### PR DESCRIPTION
Adds a couple of new examples for Web UI (also for React). It also categorizes samples under their own "Default UI" and "Custom UI" categories depending on their purpose.