### PR TITLE
Unmute player when interacting with volume slider

### DIFF
--- a/.changeset/volume-muted-align.md
+++ b/.changeset/volume-muted-align.md
@@ -1,0 +1,6 @@
+---
+'@theoplayer/web-ui': patch
+'@theoplayer/react-ui': patch
+---
+
+When the player is muted, the volume bar now shows its minimum value, and dragging the volume bar now unmutes the player.

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -68,7 +68,9 @@ export class VolumeRange extends Range {
     }
 
     protected override handleInput(): void {
-        if (this._player !== undefined && this._player.volume !== this.value) {
+        if (this._player !== undefined) {
+            // Interacting with the volume bar unmutes the player.
+            this._player.muted = false;
             this._player.volume = this.value;
         }
         super.handleInput();

--- a/src/components/VolumeRange.ts
+++ b/src/components/VolumeRange.ts
@@ -53,7 +53,8 @@ export class VolumeRange extends Range {
 
     private readonly _updateFromPlayer = () => {
         if (this._player !== undefined) {
-            this.rawValue = this._player.volume;
+            // When the player is muted, show the bar at its minimum value.
+            this.rawValue = this._player.muted ? this.min : this._player.volume;
             this._updateRange();
         }
     };


### PR DESCRIPTION
This PR adds 2 small changes:

- When the player is muted, the volume bar now reflects the minimum value (goes all the way to 0).
- When the player is muted, clicking to set a different volume on the volume bar or dragging it now unmutes the player.

Both of these were the behavior of the old VJS based UI.

The only different case still not handled is:
- When the player is muted (and thus volume bar shows 0), if you just click on the volume bar at where it is (meaning, if you also click on its 0 volume position), the player doesn't unmute with the 0 volume. VJS-based UI is doing this but I don't believe this is necessary?

Closes #120.