### PR TITLE
Set tap highlight color transparent on iOS Safari

### DIFF
--- a/.changeset/seek-bar-tap-highlight.md
+++ b/.changeset/seek-bar-tap-highlight.md
@@ -1,0 +1,6 @@
+---
+'@theoplayer/web-ui': patch
+'@theoplayer/react-ui': patch
+---
+
+Fixed a brief tap highlight appearing on the seek bar on iOS Safari when tapping or scrubbing.

--- a/src/components/Range.css
+++ b/src/components/Range.css
@@ -14,6 +14,7 @@
     padding-left: var(--theoplayer-range-padding-left, var(--theoplayer-range-padding));
     padding-right: var(--theoplayer-range-padding-right, var(--theoplayer-range-padding));
     pointer-events: auto;
+    -webkit-tap-highlight-color: transparent;
     /* needed for vertical align issue 1px off */
     font-size: 0;
 }


### PR DESCRIPTION
This is a follow up PR for #146.

Apparently this was also happening when tapping the seek bar on iOS Safari:
https://github.com/user-attachments/assets/214f564a-de07-4557-b5db-4316e97eccbb


Setting the highlight color transparent fixes it:
https://github.com/user-attachments/assets/51aeaaa6-4a38-4048-ad63-f1ddaf002c87
