### PR TITLE
docs: use strict MDX admonition title syntax

### DIFF
--- a/docs/guides/custom-component.mdx
+++ b/docs/guides/custom-component.mdx
@@ -106,7 +106,7 @@ export class MyPlayButton extends StateReceiverMixin(Button, ['player']) {
 }
 ```
 
-:::tip For TypeScript users
+:::tip[For TypeScript users]
 
 If you're using TypeScript, you can also use the `@stateReceiver` decorator instead.
 
@@ -177,7 +177,7 @@ that we can use inside our `render()` method.
     {playButtonStep3}
 </CodeBlock>
 
-:::tip For TypeScript users
+:::tip[For TypeScript users]
 
 If you're using TypeScript, you can also use the `@state` decorator instead.
 


### PR DESCRIPTION
## Summary

The documentation site is migrating to [strict MDX](https://docusaurus.io/blog/releases/3.10#strict-mdx) and dropping the `mdx1Compat.admonitions` flag. Without that flag, the legacy `:::tip Title` form renders the title as literal body text, so the two admonitions in `docs/guides/custom-component.mdx` are switched to `:::tip[For TypeScript users]`.

Link to Devin session: https://dolby.devinenterprise.com/sessions/7f6c018f420d4e30af6cd39a2274e7e4
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/7f6c018f420d4e30af6cd39a2274e7e4?variant=devin
Requested by: @MattiasBuelens